### PR TITLE
fix: @成员协助不再误触发流程重头跑

### DIFF
--- a/server/src/engine.js
+++ b/server/src/engine.js
@@ -29,6 +29,7 @@ import {
   formatSessionAutoTitle,
   injectCallArgsParam,
   extractCallArgsFromMention,
+  isMentionAssistOnly,
 } from '@acw/shared'
 import { resolveGroupAdmin, getAppSettings } from './appSettings.js'
 import { assertPathAvailable } from './pathLock.js'
@@ -1834,6 +1835,18 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
     const prevOut = parseJson(node.output_json, {})
     const ctx = parseJson(session.context_json, {})
     const fullText = text != null ? String(text) : ''
+    // 纯 @成员：不当闸门提交（应走发消息协助）
+    {
+      const enabledMembers = getDb()
+        .prepare('SELECT * FROM members WHERE enabled = 1')
+        .all()
+      if (isMentionAssistOnly(fullText, enabledMembers)) {
+        throw Object.assign(
+          new Error('纯 @ 提及请用发送消息协助，不能作为闸门/项目参数提交'),
+          { code: 'MENTION_ASSIST_ONLY' },
+        )
+      }
+    }
     ctx.lastHumanInput = fullText
     ctx.workFolderReason = ctx.workFolderReason || 'user'
 
@@ -2397,8 +2410,19 @@ export async function postUserMessage(sessionId, text, attachments = []) {
         `SELECT * FROM node_instances WHERE session_id = ? AND status = ? ORDER BY step_index LIMIT 1`,
       )
       .get(sessionId, NODE_STATUS.WAITING_HUMAN)
-    if (node && node.step_type === STEP_TYPE.HUMAN) {
-      // 人工步骤提交：走闸门，不并行 @（避免和项目参数采集冲突）
+
+    const enabledMembers = getDb()
+      .prepare('SELECT * FROM members WHERE enabled = 1')
+      .all()
+      .map((r) => ({
+        ...r,
+        config: parseJson(r.config_json, {}),
+      }))
+    const mentionOnly =
+      /@/.test(content.text || '') && isMentionAssistOnly(content.text, enabledMembers)
+
+    if (node && node.step_type === STEP_TYPE.HUMAN && !mentionOnly) {
+      // 人工步骤提交：走闸门（纯 @成员协助除外）
       await handleGateAction(sessionId, {
         action: 'submit',
         text: content.text,
@@ -2413,8 +2437,8 @@ export async function postUserMessage(sessionId, text, attachments = []) {
       }
       return { session: getSession(sessionId), newSession: false }
     }
-    // CI01：缺参拦截后，Enter 发送即补齐 #1 并重跑本步
-    if (node && node.step_type === STEP_TYPE.MEMBER) {
+    // CI01：缺参拦截后补参（纯 @协助除外）
+    if (node && node.step_type === STEP_TYPE.MEMBER && !mentionOnly) {
       const out = parseJson(node.output_json, {})
       if (out.needParams || out.reason === 'missing_param_1') {
         await handleGateAction(sessionId, {
@@ -2425,13 +2449,13 @@ export async function postUserMessage(sessionId, text, attachments = []) {
         return { session: getSession(sessionId), newSession: false, needParamsFilled: true }
       }
     }
-    // waiting gate but user typed — 记 pending 附言，不推进、不通过/拒绝（可 @ 成员协助）
+    // waiting / 纯 @协助：记消息，可 @ 成员，不推进流程
     addMessage(sessionId, {
       role: 'user',
       type: 'text',
       content,
     })
-    if (node) {
+    if (node && !mentionOnly) {
       appendPendingGateNote(sessionId, node, content.text)
     }
     if (/@/.test(content.text || '')) {

--- a/shared/index.js
+++ b/shared/index.js
@@ -215,6 +215,31 @@ export function formatAddedParamsText(added, startIndex) {
 }
 
 /**
+ * 去掉已识别的 @成员名后是否几乎为空 → 视为「仅 @协助」，不当项目参数提交
+ * @param {string} text
+ * @param {Array<{display_name?: string, name?: string}>} [memberList]
+ */
+export function isMentionAssistOnly(text, memberList = []) {
+  let rest = String(text || '')
+  if (!rest.includes('@')) return false
+  const names = []
+  for (const m of memberList || []) {
+    if (m?.display_name) names.push(String(m.display_name))
+    if (m?.name) names.push(String(m.name))
+  }
+  names.sort((a, b) => b.length - a.length)
+  for (const n of [...new Set(names)]) {
+    const escaped = n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const re = new RegExp(`@${escaped}(?=$|[\\s,，、@])`, 'g')
+    rest = rest.replace(re, ' ')
+  }
+  if (!names.length) {
+    rest = rest.replace(/@[\w\u4e00-\u9fff·.\-]+/g, ' ')
+  }
+  return !rest.replace(/[\s,，、]/g, '').length
+}
+
+/**
  * 从节点 output 取整段业务正文（不切分）
  * @param {unknown} output
  * @returns {string}

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -379,23 +379,8 @@
                     <div v-if="atOpen" class="slash-panel at-panel">
                       <div class="slash-panel-head">
                         <span>@ 提及</span>
-                        <span class="at-panel-tip">成员协助 · 或选节点重新开始</span>
+                        <span class="at-panel-tip">仅成员协助 · 不重跑流程 · 重跑请用右侧「从此重新开始」</span>
                       </div>
-                      <div v-if="filteredAtNodes.length" class="at-section-label">流程节点 · 重新开始</div>
-                      <button
-                        v-for="(n, i) in filteredAtNodes"
-                        :key="n.id"
-                        type="button"
-                        class="slash-item at-item-node"
-                        :class="{ active: i === atIndex }"
-                        @mousedown.prevent="pickAtNode(n)"
-                      >
-                        <span class="at-avatar at-avatar-node">{{ n.step_index + 1 }}</span>
-                        <span class="slash-name">{{ n.title || `步骤 ${n.step_index + 1}` }}</span>
-                        <span class="slash-desc"
-                          >{{ statusLabel(n.status) || n.status }} · 从此重跑</span
-                        >
-                      </button>
                       <div class="at-section-label">成员 · 流程外协助</div>
                       <div v-if="!filteredAtMembers.length" class="slash-empty">无匹配成员</div>
                       <button
@@ -403,9 +388,7 @@
                         :key="m.id"
                         type="button"
                         class="slash-item"
-                        :class="{
-                          active: i + filteredAtNodes.length === atIndex,
-                        }"
+                        :class="{ active: i === atIndex }"
                         @mousedown.prevent="insertAtMember(m)"
                       >
                         <span class="at-avatar">{{ (m.display_name || m.name || '?').slice(0, 1) }}</span>
@@ -922,6 +905,7 @@ import {
   abbrGroupTag,
   formatSessionAutoTitle,
   extractCallArgsFromSlash,
+  isMentionAssistOnly,
 } from '@acw/shared'
 import { api, connectSessionWs } from '../api'
 import AppLogo from '../components/AppLogo.vue'
@@ -1000,18 +984,6 @@ const filteredAtMembers = computed(() => {
         .toLowerCase()
         .includes(q),
   )
-})
-
-/** @ 面板中的流程节点（可从此重新开始） */
-const filteredAtNodes = computed(() => {
-  const nodes = detail.value?.nodes || []
-  const q = (atQuery.value || '').toLowerCase().trim()
-  if (!q) return nodes
-  return nodes.filter((n) => {
-    const title = String(n.title || '').toLowerCase()
-    const idx = String(n.step_index + 1)
-    return title.includes(q) || idx === q || `步骤${idx}`.includes(q) || q === '节点'
-  })
 })
 
 const filterOptions = [
@@ -2263,11 +2235,10 @@ function onComposerKeydown(e) {
     }
   }
 
-  // @ 面板：节点 + 成员
+  // @ 面板：仅成员协助（节点重跑已从面板移除，避免误触重头跑）
   if (atOpen.value) {
-    const nodes = filteredAtNodes.value
     const members = filteredAtMembers.value
-    const total = nodes.length + members.length
+    const total = members.length
     if (e.key === 'Escape') {
       e.preventDefault()
       atOpen.value = false
@@ -2289,9 +2260,7 @@ function onComposerKeydown(e) {
       if (!total) return
       e.preventDefault()
       e.stopPropagation()
-      const i = atIndex.value
-      if (i < nodes.length) pickAtNode(nodes[i] || nodes[0])
-      else insertAtMember(members[i - nodes.length] || members[0])
+      insertAtMember(members[atIndex.value] || members[0])
       return
     }
   }
@@ -2419,16 +2388,7 @@ async function insertHashItem(h) {
   await replaceSenderText(stripped ? `${stripped} ${insert}` : insert)
 }
 
-/** @ 选中流程节点 → 确认是否从此重新开始 */
-async function pickAtNode(n) {
-  if (!n || !activeId.value) return
-  atOpen.value = false
-  atQuery.value = ''
-  clearSender()
-  await confirmRestartFromNode(n)
-}
-
-/** 从节点重新开始（归档前/后均可） */
+/** 从节点重新开始（归档前/后均可；入口在右侧流程轨） */
 async function confirmRestartFromNode(n) {
   if (!n || !activeId.value) return
   const title = n.title || `步骤 ${n.step_index + 1}`
@@ -2521,13 +2481,26 @@ async function onSenderSubmit() {
     return
   }
 
-  // 人工输入 / 缺参补齐闸门：Enter = 提交闸门（共用底部输入）
+  // 人工输入 / 缺参补齐闸门：Enter = 提交闸门（纯 @成员协助除外，不推进流程）
   const g = pendingGate.value
-  if (g?.content?.mode === 'human_input' || g?.content?.mode === 'need_params') {
+  const mentionAssist =
+    !!text &&
+    isMentionAssistOnly(
+      text,
+      (members.value || []).map((m) => ({
+        display_name: m.display_name,
+        name: m.name,
+      })),
+    )
+  if (
+    (g?.content?.mode === 'human_input' || g?.content?.mode === 'need_params') &&
+    !mentionAssist
+  ) {
     await submitHuman(g)
     return
   }
   // 启动闸门 / 审核闸门：Enter 只发消息，保持 pending，不默认通过或拒绝
+  // 人工闸门下纯 @：走发消息协助，不当项目参数提交
 
   if (!text && !atts.length) return
 
@@ -2566,9 +2539,23 @@ function nextIdempotencyKey(action, nodeInstanceId) {
 
 async function submitHuman(m) {
   if (gating.value) return
+  const text = readSenderText()
+  // 闸门「提交」按钮：纯 @ 协助不当参数
+  if (
+    text &&
+    isMentionAssistOnly(
+      text,
+      (members.value || []).map((x) => ({
+        display_name: x.display_name,
+        name: x.name,
+      })),
+    )
+  ) {
+    await onSenderSubmit()
+    return
+  }
   gating.value = true
   try {
-    const text = readSenderText()
     await api.sessions.gate(activeId.value, {
       action: 'submit',
       text,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
群聊里 `@统一管理员` 时，流程会像从「输入项目信息」重头开始，体验不合理。

## 根因
1. `@` 面板把「流程节点 · 从此重跑」和成员混在一起，回车易误选第一步并触发 `restartFromNode`
2. 人工步/缺参闸门等待时，纯 `@成员` 被当成闸门提交（写入项目参数），看起来像流程重开

## 改动
- `@` 面板只保留成员协助；节点重跑仅保留右侧流程轨「从此重新开始」
- 等人/缺参时纯 `@` 走发消息协助，不推进流程、不当 `#1/#2`
- 服务端 `postUserMessage` 与闸门 `submit` 同步识别 `isMentionAssistOnly`

## 验证建议
1. 开演示流停在「输入项目信息」
2. 输入 `@统一管理员` 发送 → 应通知协助，步骤仍停在当前人工步
3. 右侧「从此重新开始」仍可手动重跑
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

