### PR TITLE
fix: 缩写标签 hover 展示全文

### DIFF
--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -28,6 +28,7 @@
                     round
                     effect="plain"
                     type="info"
+                    :title="g.title"
                   >
                     {{ abbrGroupTag(g.title) }}
                   </el-tag>
@@ -89,8 +90,8 @@
             <el-tooltip
               :content="item.hoverTitle || item.label"
               placement="right"
-              :disabled="!item.hoverTitle"
-              :show-after="300"
+              :disabled="!(item.hoverTitle || item.label)"
+              :show-after="200"
             >
               <span class="conv-label-wrap">
                 <span v-if="item.pinned" class="conv-pin" aria-hidden="true">📌</span>
@@ -102,6 +103,7 @@
                   round
                   effect="plain"
                   type="info"
+                  :title="item.hoverTitle || item.groupAbbr"
                 >
                   {{ item.groupAbbr }}
                 </el-tag>
@@ -1405,20 +1407,20 @@ const filteredSessions = computed(() => {
   })
 })
 
-/** 会话列表：#1 正文 + 群模板缩写标签；整行 hover 展示群全称 */
+/** 会话列表：#1 正文 + 群模板缩写标签；hover 气泡展示全文（前缀 + 群全称） */
 function sessionListParts(s) {
   const ctx = s?.context && typeof s.context === 'object' ? s.context : {}
-  const groupTitle = s.groupTitle || ctx.groupTitle || ''
+  const groupTitle = String(s.groupTitle || ctx.groupTitle || '').trim()
   const abbr = s.groupTitleAbbr || ctx.groupTitleAbbr || abbrGroupTag(groupTitle)
-  const hoverTitle = groupTitle || s.title || ''
 
   // 手改过：整段标题，不用缩写标签
   if (ctx.titleAuto === false && s.title) {
+    const full = String(s.title).trim()
     return {
-      label: s.title,
-      labelPrefix: s.title,
+      label: full,
+      labelPrefix: full,
       groupAbbr: '',
-      hoverTitle: hoverTitle || s.title,
+      hoverTitle: full,
     }
   }
 
@@ -1439,11 +1441,18 @@ function sessionListParts(s) {
     groupTitle ||
     '未命名'
 
+  // 全文：优先「#1 · 群全称」，否则群全称 / 会话标题
+  let hoverTitle = ''
+  if (p1 && groupTitle) hoverTitle = `${p1} · ${groupTitle}`
+  else if (groupTitle) hoverTitle = groupTitle
+  else if (p1) hoverTitle = p1
+  else hoverTitle = String(s.title || label || '').trim()
+
   return {
     label,
     labelPrefix,
     groupAbbr,
-    hoverTitle: hoverTitle || label,
+    hoverTitle,
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

缩写标签（如「演示」）hover 气泡改为展示**全文**，例如 `@统一管理员 · 演示流`。

## 变更

- 会话列表：`hoverTitle` = `#1 · 群全称`（有则拼全）
- 缩写 `el-tag` 增加 `title` 兜底
- 开聊下拉群模板缩写标签 `:title="g.title"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

