### PR TITLE
fix: node:sqlite 补齐 transaction，修复 @临时协助报错

### DIFF
--- a/server/src/db.js
+++ b/server/src/db.js
@@ -32,6 +32,31 @@ function openNodeSqliteCompat(dbPath) {
     exec(sql) {
       return raw.exec(sql)
     },
+    /**
+     * 对齐 better-sqlite3：db.transaction(fn) 返回可调用函数。
+     * 运行包在 ABI 不匹配回退 node:sqlite 时必须提供，否则 @/插队插入临时协助会报
+     *「db2.transaction is not a function」。
+     */
+    transaction(fn) {
+      if (typeof fn !== 'function') {
+        throw new TypeError('db.transaction(fn) requires a function')
+      }
+      return (...args) => {
+        raw.exec('BEGIN')
+        try {
+          const result = fn(...args)
+          raw.exec('COMMIT')
+          return result
+        } catch (e) {
+          try {
+            raw.exec('ROLLBACK')
+          } catch {
+            /* ignore */
+          }
+          throw e
+        }
+      }
+    },
     pragma(src) {
       const body = String(src || '').trim()
       if (!body) return undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因
运行包在 better-sqlite3 ABI 不匹配时会回退 Node 22+ 内置 `node:sqlite`。兼容层原先只包了 `prepare/exec/pragma/close`，没有 `transaction`。

演示流里发 `@示例回声` 会走 `insertOffsiteAtCursor` → `db.transaction(...)`，于是前端弹出：

`db2.transaction is not a function`

（打包后变量名被压缩成 `db2`。）

## 修复
在 `server/src/db.js` 的 `openNodeSqliteCompat` 对齐 better-sqlite3：提供 `db.transaction(fn)`（BEGIN / COMMIT / ROLLBACK）。

## 验证
本地用 `node:sqlite` 冒烟：事务提交与回滚正常。

合入后需重新打运行包 / 重启服务后再试演示流。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

