### PR TITLE
ux: 顶栏去掉多余的资源与恢复

### DIFF
--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -3163,19 +3163,6 @@ async function doArchive() {
   }
 }
 
-async function doUnarchive() {
-  const id = activeId.value
-  if (!id) return
-  try {
-    await api.sessions.unarchive(id)
-    await loadDetail(id)
-    sessions.value = await api.sessions.list()
-    ElMessage.success('已恢复')
-  } catch (e) {
-    // 业务异常不 toast Error
-  }
-}
-
 /** @param {string} [targetId] 侧栏菜单可传指定会话 id；顶栏按钮不传则删当前 */
 async function doDelete(targetId) {
   const id = targetId || activeId.value

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -182,7 +182,6 @@
             >
               {{ detail.session.pinned ? '取消置顶' : '置顶' }}
             </el-button>
-            <el-button size="default" text bg @click="openResourcesTab">资源</el-button>
             <el-button
               v-if="detail.session.status !== 'archived'"
               size="default"
@@ -191,16 +190,6 @@
               @click="doArchive"
             >
               归档
-            </el-button>
-            <el-button
-              v-else
-              size="default"
-              text
-              bg
-              type="primary"
-              @click="doUnarchive"
-            >
-              恢复
             </el-button>
             <el-button size="default" text bg type="danger" @click="doDelete">删除</el-button>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
顶栏「资源」「恢复」与既有入口重复，去掉以减噪音。

## 改动
- 去掉顶栏 **资源**（右栏已有资源 Tab）
- 去掉顶栏 **恢复**（已归档：再发消息即恢复，底栏已有说明；续跑用「从这里继续」）
- 删除未再使用的 `doUnarchive`
- 保留：置顶 / 归档 / 删除

顶栏未归档时仍可一键归档；已归档时顶栏只留置顶与删除。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5454f9fe-3876-4ba0-8e25-4799b0d8f996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

