### PR TITLE
群聊消息自动记入 # 参数与群报告

### DIFF
--- a/server/src/engine.js
+++ b/server/src/engine.js
@@ -522,6 +522,103 @@ function bindGateHumanInput(sessionId, {
   return { full, note }
 }
 
+/**
+ * 群聊用户消息：追加 #1… 参数并记入群报告 userNotes（与人工闸门提交共用同一套 paramsList）
+ */
+function recordUserChatInput(
+  sessionId,
+  text,
+  {
+    action = 'chat',
+    actionLabel = '群聊',
+    nodeTitle,
+    nodeInstanceId,
+  } = {},
+) {
+  const note = text != null ? String(text).trim() : ''
+  if (!note) return null
+  const session = getSession(sessionId)
+  if (!session) return null
+  const group = getGroup(session.group_id)
+  const steps = parseJson(group?.steps_json, [])
+  const ctx = parseJson(session.context_json, {})
+  ctx.lastHumanInput = note
+  const parsed = appendProjectParams(ctx, note)
+  ctx.projectInfoRaw = [ctx.projectInfoRaw, parsed.raw]
+    .filter((s) => s != null && String(s).trim())
+    .join('\n')
+  ctx.paramsList = parsed.list
+  const gObj = group ? { ...group, steps } : null
+  const sysCard =
+    ctx.params?.[SYSTEM_PARAM_KEYS.GROUP_CARD] ||
+    ctx.groupCard ||
+    (gObj
+      ? formatGroupCard(gObj, {
+          memberNameOf: (id) => {
+            const m = getMember(id)
+            return m?.display_name || m?.name || id
+          },
+        })
+      : '')
+  if (sysCard) ctx.groupCard = sysCard
+  if (gObj) ctx.groupFolder = resolveGroupFolder(gObj, ctx)
+  ctx.params = mergeSystemParams(
+    {
+      ...parsed.map,
+      [SYSTEM_PARAM_KEYS.CALL_ARGS]: note,
+    },
+    {
+      group: gObj,
+      sessionContext: ctx,
+      memberNameOf: (id) => {
+        const m = getMember(id)
+        return m?.display_name || m?.name || id
+      },
+    },
+  )
+  ctx.userNotes = Array.isArray(ctx.userNotes) ? ctx.userNotes : []
+  ctx.userNotes.push({
+    at: nowIso(),
+    action,
+    actionLabel,
+    text: note,
+    nodeTitle: nodeTitle || undefined,
+    nodeInstanceId: nodeInstanceId || undefined,
+  })
+  const autoTitle = syncAutoSessionTitle(ctx, group)
+  updateSession(sessionId, {
+    context_json: JSON.stringify(ctx),
+    ...(autoTitle ? { title: autoTitle } : {}),
+  })
+  refreshSessionAnnouncement(sessionId)
+  return parsed
+}
+
+/** 临时协助节点：累积群聊正文，供群报告节点 I/O 展示 */
+function appendOffsiteNodeChat(sessionId, nodeId, text) {
+  const note = text != null ? String(text).trim() : ''
+  if (!note || !nodeId) return
+  const node = getDb().prepare('SELECT * FROM node_instances WHERE id = ?').get(nodeId)
+  if (!node || node.step_type !== STEP_TYPE.OFFSITE) return
+  const prevIn = parseJson(node.input_json, {})
+  const prevOut = parseJson(node.output_json, {})
+  const prevHuman = String(prevIn.humanInput || '').trim()
+  const humanInput = prevHuman ? `${prevHuman}\n${note}` : note
+  persistNodeIo(sessionId, nodeId, {
+    input: {
+      ...prevIn,
+      kind: 'offsite',
+      humanInput,
+      text: note,
+      lastChatAt: nowIso(),
+    },
+    output: {
+      ...prevOut,
+      lastChat: note,
+    },
+  })
+}
+
 /** 用户参数 + #群聊 名片 + #文件夹 */
 function resolveParamsMap(sessionContext, group) {
   const user = getParamsMap(sessionContext)
@@ -3422,22 +3519,12 @@ function appendPendingGateNote(sessionId, node, text) {
       ],
     }),
   })
-  const session = getSession(sessionId)
-  if (session) {
-    const ctx = parseJson(session.context_json, {})
-    ctx.lastHumanInput = note
-    ctx.userNotes = Array.isArray(ctx.userNotes) ? ctx.userNotes : []
-    ctx.userNotes.push({
-      at: nowIso(),
-      action: 'pending',
-      actionLabel: '待定',
-      text: note,
-      nodeTitle: node.title || `步骤 ${Number(node.step_index) + 1}`,
-      nodeInstanceId: node.id,
-    })
-    updateSession(sessionId, { context_json: JSON.stringify(ctx) })
-  }
-  refreshSessionAnnouncement(sessionId)
+  recordUserChatInput(sessionId, note, {
+    action: 'pending',
+    actionLabel: '待定',
+    nodeTitle: node.title || `步骤 ${Number(node.step_index) + 1}`,
+    nodeInstanceId: node.id,
+  })
 }
 
 export async function postUserMessage(sessionId, text, attachments = []) {
@@ -3533,8 +3620,16 @@ export async function postUserMessage(sessionId, text, attachments = []) {
       node_instance_id: offsiteNode?.id || null,
       content: { ...content, offsite: !!offsiteNode },
     })
-    if (node && !mentionOnly) {
-      appendPendingGateNote(sessionId, node, content.text)
+    if ((content.text || '').trim()) {
+      if (node && !mentionOnly) {
+        appendPendingGateNote(sessionId, node, content.text)
+      } else {
+        recordUserChatInput(sessionId, content.text, {
+          nodeTitle: offsiteNode?.title || node?.title,
+          nodeInstanceId: offsiteNode?.id || node?.id,
+        })
+      }
+      if (offsiteNode?.id) appendOffsiteNodeChat(sessionId, offsiteNode.id, content.text)
     }
     if (/@/.test(content.text || '')) {
       setImmediate(() => {
@@ -3567,6 +3662,13 @@ export async function postUserMessage(sessionId, text, attachments = []) {
       node_instance_id: offsiteNode?.id || null,
       content: hasMention ? { ...content, offsite: true } : content,
     })
+    if ((content.text || '').trim()) {
+      recordUserChatInput(sessionId, content.text, {
+        nodeTitle: offsiteNode?.title,
+        nodeInstanceId: offsiteNode?.id,
+      })
+      if (offsiteNode?.id) appendOffsiteNodeChat(sessionId, offsiteNode.id, content.text)
+    }
     if (hasMention) {
       setImmediate(() => {
         invokeMentionedMembers(sessionId, content.text).catch((e) =>

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -1954,7 +1954,7 @@ const composerFooterHint = computed(() => {
   if (pendingGate.value) {
     return '待确认与消息共用下方输入框 · 附言会记入群报告'
   }
-  return '# 插入正文（群聊/文件夹/参数/输出）· @成员协助'
+  return '# 插入正文（群聊/文件夹/参数/输出）· @成员协助 · 发送会写入 # 与群报告'
 })
 
 function statusLabel(s) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在会话进行中（例如 `@cursor` 临时协助、主流程未停在人工闸门时），用户直接发送的「你好」「你不好」等普通群聊消息只会出现在聊天气泡里，不会进入右侧 **# 参数**（文本锚点）和 **群报告**。

## 原因

`postUserMessage` 在非 `WAITING_HUMAN` 人工提交路径下仅写入 `messages` 表，未更新 `context_json.paramsList` / `userNotes`，也未刷新 `ANNOUNCEMENT.md`。

## 改动

- 新增 `recordUserChatInput`：按既有规则用 `appendProjectParams` 追加 `#1`、`#2`…，写入 `userNotes` 并刷新群报告。
- 场外协助节点通过 `appendOffsiteNodeChat` 累积 `humanInput`，群报告「节点输入/输出」可看到协助期间的聊天正文。
- 闸门附言路径复用同一套参数追加逻辑（`appendPendingGateNote` 内调用 `recordUserChatInput`）。
- 输入框底部提示说明：发送会写入 # 与群报告。

## 验证

- `node --check server/src/engine.js` 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

