### PR TITLE
start.mjs：无头浏览器随启动脚本一并退出

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ WebSocket：`ws://127.0.0.1:3780/ws?sessionId=<id>`
 | `server/config/about.json` | 版本、更新日志、更新地址、本地说明 |
 | 环境变量 `ACW_PORT` | API 端口，默认 `3780` |
 | 环境变量 `ACW_DATA_ROOT` | 数据根目录，默认 `./data` |
+| 环境变量 `ACW_HEADLESS_BROWSER` | `1` 时用 Playwright 无头加载首页（无界面）；**结束 `start.mjs`（Ctrl+C）会同时关闭无头浏览器并停服务**。需 `npm install` 与 `npx playwright install chromium` |
 
 ---
 

--- a/start.mjs
+++ b/start.mjs
@@ -2,7 +2,7 @@
  * 一键启动（压缩包 / 本机推荐入口）
  * - 必要时 npm install
  * - 启动 API（默认不随浏览器退出；需要时设 ACW_AUTO_EXIT=1）
- * - 自动打开浏览器
+ * - 自动打开浏览器；或 ACW_HEADLESS_BROWSER=1 用 Playwright 无头加载页面（关脚本即关浏览器）
  *
  * 用法：node start.mjs
  * 或双击 start.bat / ./start.sh
@@ -21,6 +21,15 @@ const AUTO_EXIT =
   process.env.ACW_AUTO_EXIT === '1' ||
   process.env.ACW_AUTO_EXIT === 'true' ||
   process.env.ACW_AUTO_EXIT === 'yes'
+/** Playwright 无头打开工作台（无界面）；退出 start 进程时自动 browser.close() */
+const HEADLESS_BROWSER =
+  process.env.ACW_HEADLESS_BROWSER === '1' ||
+  process.env.ACW_HEADLESS_BROWSER === 'true' ||
+  process.env.ACW_HEADLESS_BROWSER === 'yes'
+
+/** @type {import('playwright').Browser | null} */
+let headlessBrowser = null
+let shuttingDown = false
 
 function log(...a) {
   console.log('[acw-start]', ...a)
@@ -87,13 +96,41 @@ function openBrowser(url) {
   }
 }
 
+async function closeHeadlessBrowser() {
+  if (!headlessBrowser) return
+  try {
+    await headlessBrowser.close()
+  } catch {
+    /* ignore */
+  }
+  headlessBrowser = null
+}
+
+async function openHeadlessBrowser(url) {
+  let chromium
+  try {
+    ;({ chromium } = await import('playwright'))
+  } catch {
+    throw new Error(
+      '无头模式需要 dev 依赖 playwright：在项目根执行 npm install && npx playwright install chromium',
+    )
+  }
+  headlessBrowser = await chromium.launch({ headless: true })
+  const page = await headlessBrowser.newPage()
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 })
+  log('无头浏览器已加载', url)
+  log('提示：无界面；按 Ctrl+C 或关闭本窗口将自动关闭无头浏览器并停止服务')
+}
+
 async function ensureInstall() {
-  if (exists(path.join(ROOT, 'node_modules', 'better-sqlite3'))) {
+  const sqliteOk = exists(path.join(ROOT, 'node_modules', 'better-sqlite3'))
+  const playwrightOk = exists(path.join(ROOT, 'node_modules', 'playwright'))
+  if (sqliteOk && (!HEADLESS_BROWSER || playwrightOk)) {
     log('依赖已就绪')
     return
   }
   log('首次启动，正在 npm install …')
-  await run('npm', ['install', '--omit=dev'])
+  await run('npm', HEADLESS_BROWSER ? ['install'] : ['install', '--omit=dev'])
 }
 
 async function main() {
@@ -149,26 +186,29 @@ async function main() {
     }
   }
 
-  const shutdown = () => {
+  const shutdown = async (code = 0) => {
+    if (shuttingDown) return
+    shuttingDown = true
+    await closeHeadlessBrowser()
     killChild()
+    process.exit(code)
   }
   process.on('SIGINT', () => {
-    shutdown()
-    process.exit(0)
+    shutdown(0)
   })
   process.on('SIGTERM', () => {
-    shutdown()
-    process.exit(0)
+    shutdown(0)
   })
   process.on('SIGHUP', () => {
-    shutdown()
-    process.exit(0)
+    shutdown(0)
   })
-  process.on('exit', killChild)
+  process.on('exit', () => {
+    killChild()
+  })
 
   child.on('exit', (code) => {
     log('服务已退出', code)
-    process.exit(code || 0)
+    shutdown(code || 0)
   })
 
   try {
@@ -180,13 +220,24 @@ async function main() {
   }
 
   const url = `http://127.0.0.1:${PORT}/`
-  log('打开浏览器', url)
-  if (AUTO_EXIT) {
-    log('提示：已开启 ACW_AUTO_EXIT，关闭浏览器后后台可能退出')
+  if (HEADLESS_BROWSER) {
+    log('无头浏览器模式', url)
+    try {
+      await openHeadlessBrowser(url)
+    } catch (e) {
+      log(e.message || e)
+      await shutdown(1)
+      return
+    }
   } else {
-    log('提示：关闭本窗口（或 Ctrl+C）即可结束服务；关浏览器不会停服务')
+    log('打开浏览器', url)
+    if (AUTO_EXIT) {
+      log('提示：已开启 ACW_AUTO_EXIT，关闭浏览器后后台可能退出')
+    } else {
+      log('提示：关闭本窗口（或 Ctrl+C）即可结束服务；关浏览器不会停服务')
+    }
+    openBrowser(url)
   }
-  openBrowser(url)
 }
 
 main().catch((e) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 需求

无头浏览器加载 Web 页面，**用户结束 `start.mjs`（Ctrl+C / 关终端）时自动关闭该无头页面并停服务**。

## 实现

- 环境变量 `ACW_HEADLESS_BROWSER=1`：健康检查通过后，用 Playwright `chromium.launch({ headless: true })` 打开 `http://127.0.0.1:<port>/`。
- `SIGINT` / `SIGTERM` / `SIGHUP` 或服务子进程退出时：先 `browser.close()`，再结束 API 子进程。
- 无头模式首次安装会执行完整 `npm install`（需 `playwright` dev 依赖）；文档注明需 `npx playwright install chromium`。

## 用法

```bash
npx playwright install chromium   # 首次
ACW_HEADLESS_BROWSER=1 node start.mjs
# Ctrl+C → 无头浏览器与服务一并退出
```

默认不设该变量时，行为与原来一致（系统浏览器 `xdg-open` / `start`）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

