### PR TITLE
fix(ui): 归档顶栏「失败」改为「介入归档」三态

### DIFF
--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -92,7 +92,7 @@ apple-co-work/
 | **#群聊** | 整份群模板名片（开聊即生成，不依赖用户输入） |
 | **#文件夹** | 群聊工作文件夹绝对/配置路径（开聊即写入） |
 | **群报告 ANNOUNCEMENT.md** | **# 参数全集**（`#群聊` / `#文件夹` / `#1`…）+ **各子节点输入/输出**；人工可 PUT 编辑；手改后 `announcementManual=true`，自动汇总不覆盖除非 force；路径仍为 `journals/sessions/{sessionId}/ANNOUNCEMENT.md`（文件名兼容） |
-| **归档确认** | 完成/失败/拒绝后进入 `pendingArchive`（**不立刻归档**）；待确认时只杀非 `detach` 进程（Cursor CLI 等仅唤起窗口保留）；手工「归档」/闸门同意，或超时（默认 **3h**，`autoArchiveHours`）→ `archiveSession`：**必杀本会话全部进程**（含 detach）；`archive_reason` 区分结果（`failed`/`rejected`→失败，其余→成功） |
+| **归档确认** | 完成/失败/拒绝后进入 `pendingArchive`（**不立刻归档**）；待确认时只杀非 `detach` 进程（Cursor CLI 等仅唤起窗口保留）；手工「归档」/闸门同意，或超时（默认 **3h**，`autoArchiveHours`）→ `archiveSession`：**必杀本会话全部进程**（含 detach）；`archive_reason` 区分会话级结果（`failed`/`rejected` 等→顶栏「失败」）；若已确认归档但时间轴仍有 `failed` 步骤（如闸门放行）→ 顶栏「介入归档」 |
 | **审核三态** | 节点 `output.humanAction`：`pending` / `approve` / `reject`；脚本产出或输入框消息保持 `pending`；仅闸门「同意/拒绝」改态并推进 |
 | **归档 / 解档 / 再发** | **已决**：归档只释资源；再发仍在本会话、不新开群聊；可无限归档；续跑=本会话追加克隆节点。详见 [mvp.md §1.0](./mvp.md) 与 `SESSION_ARCHIVE_RULES`。 |
 | **从节点重开** | `POST /sessions/:id/restart-from-node`：本会话线性追加克隆并开跑（场外无此操作）；已归档则先解档 |

--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -92,7 +92,7 @@ apple-co-work/
 | **#群聊** | 整份群模板名片（开聊即生成，不依赖用户输入） |
 | **#文件夹** | 群聊工作文件夹绝对/配置路径（开聊即写入） |
 | **群报告 ANNOUNCEMENT.md** | **# 参数全集**（`#群聊` / `#文件夹` / `#1`…）+ **各子节点输入/输出**；人工可 PUT 编辑；手改后 `announcementManual=true`，自动汇总不覆盖除非 force；路径仍为 `journals/sessions/{sessionId}/ANNOUNCEMENT.md`（文件名兼容） |
-| **归档确认** | 完成/失败/拒绝后进入 `pendingArchive`（**不立刻归档**）；待确认时只杀非 `detach` 进程（Cursor CLI 等仅唤起窗口保留）；手工「归档」/闸门同意，或超时（默认 **3h**，`autoArchiveHours`）→ `archiveSession`：**必杀本会话全部进程**（含 detach）；`archive_reason` 区分会话级结果（`failed`/`rejected` 等→顶栏「失败」）；若已确认归档但时间轴仍有 `failed` 步骤（如闸门放行）→ 顶栏「介入归档」 |
+| **归档确认** | 完成/失败/拒绝后进入 `pendingArchive`（**不立刻归档**）；待确认时只杀非 `detach` 进程（Cursor CLI 等仅唤起窗口保留）；手工「归档」/闸门同意，或超时（默认 **3h**，`autoArchiveHours`）→ `archiveSession`：**必杀本会话全部进程**（含 detach）；`archive_reason` 区分会话级结果（`failed`/`rejected` 等→顶栏「失败」）；若已确认归档但时间轴仍有 `failed` 步骤→顶栏「介入归档」；侧栏角标文案「归档 / 介入 / 失败」（表示已归档及结果，不用「成」） |
 | **审核三态** | 节点 `output.humanAction`：`pending` / `approve` / `reject`；脚本产出或输入框消息保持 `pending`；仅闸门「同意/拒绝」改态并推进 |
 | **归档 / 解档 / 再发** | **已决**：归档只释资源；再发仍在本会话、不新开群聊；可无限归档；续跑=本会话追加克隆节点。详见 [mvp.md §1.0](./mvp.md) 与 `SESSION_ARCHIVE_RULES`。 |
 | **从节点重开** | `POST /sessions/:id/restart-from-node`：本会话线性追加克隆并开跑（场外无此操作）；已归档则先解档 |

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -124,6 +124,12 @@
                   >成</span
                 >
                 <span
+                  v-else-if="item.archiveOutcome === 'involved'"
+                  class="conv-badge conv-badge--involved"
+                  title="介入归档（曾有人工放行或含失败步骤）"
+                  >介</span
+                >
+                <span
                   v-else-if="item.archiveOutcome === 'failed'"
                   class="conv-badge conv-badge--fail"
                   title="归档失败"
@@ -684,7 +690,7 @@
             ·
             <span
               class="flow-archive-outcome"
-              :class="archiveOutcomeTag.ok ? 'is-ok' : 'is-fail'"
+              :class="archiveOutcomeTag.outcomeClass"
               >{{ archiveOutcomeTag.label }}</span
             >
           </template>
@@ -1803,16 +1809,35 @@ const needsHuman = computed(() => {
   return !!pendingGate.value
 })
 
+/** archive_reason 表示会话级归档失败（非单步脚本失败） */
+const ARCHIVE_REASON_FAILED = new Set([
+  'failed',
+  'rejected',
+  'error',
+  'fail',
+  'cancelled',
+  'interrupted_discard',
+])
+
+function nodeCountsAsArchiveInvolvedFailure(n) {
+  if (!n || n.status !== 'failed') return false
+  if (n.step_type === 'archive') return false
+  return true
+}
+
 /**
- * 归档结果：success | failed | null
- * 依据 archive_reason；详情页可结合节点失败态
+ * 归档结果：success | involved | failed | null
+ * - failed：archive_reason 为失败/拒绝等
+ * - involved：已确认归档，但时间轴上仍有失败步骤（常见：闸门同意后继续）
+ * - success：其余
  */
 function archiveOutcomeOf(session, nodes) {
   if (!session || session.status !== 'archived') return null
   const r = String(session.archive_reason || '').toLowerCase()
-  if (['failed', 'rejected', 'error', 'fail'].includes(r)) return 'failed'
-  if (Array.isArray(nodes) && nodes.some((n) => n.status === 'failed')) return 'failed'
-  // auto_completed / completed / manual / timeout / 其它 → 成功归档
+  if (ARCHIVE_REASON_FAILED.has(r)) return 'failed'
+  if (Array.isArray(nodes) && nodes.some(nodeCountsAsArchiveInvolvedFailure)) {
+    return 'involved'
+  }
   return 'success'
 }
 
@@ -1820,8 +1845,13 @@ const archiveOutcomeTag = computed(() => {
   if (!detail.value?.session) return null
   const o = archiveOutcomeOf(detail.value.session, detail.value.nodes)
   if (!o) return null
-  if (o === 'failed') return { label: '失败', type: 'danger', ok: false }
-  return { label: '成功', type: 'success', ok: true }
+  if (o === 'failed') {
+    return { label: '失败', type: 'danger', outcomeClass: 'is-fail', ok: false }
+  }
+  if (o === 'involved') {
+    return { label: '介入归档', type: 'warning', outcomeClass: 'is-involved', ok: false }
+  }
+  return { label: '成功', type: 'success', outcomeClass: 'is-ok', ok: true }
 })
 
 /** 群报告：启动说明 */
@@ -3435,6 +3465,9 @@ loadLists().then(() => {
 }
 .conv-badge--fail {
   background: linear-gradient(145deg, #f78989, #f56c6c);
+}
+.conv-badge--involved {
+  background: linear-gradient(145deg, #f0c78a, #e6a23c);
 }
 
 /* —— 会话顶栏（mac 标题栏气质） —— */
@@ -5174,6 +5207,10 @@ loadLists().then(() => {
 }
 .flow-archive-outcome.is-fail {
   color: var(--el-color-danger);
+  font-weight: 600;
+}
+.flow-archive-outcome.is-involved {
+  color: var(--el-color-warning);
   font-weight: 600;
 }
 .flow-step-actions {

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -118,22 +118,11 @@
                   >{{ item.label }}</span
                 >
                 <span
-                  v-if="item.archiveOutcome === 'success'"
-                  class="conv-badge conv-badge--ok"
-                  title="归档成功"
-                  >成</span
-                >
-                <span
-                  v-else-if="item.archiveOutcome === 'involved'"
-                  class="conv-badge conv-badge--involved"
-                  title="介入归档（曾有人工放行或含失败步骤）"
-                  >介</span
-                >
-                <span
-                  v-else-if="item.archiveOutcome === 'failed'"
-                  class="conv-badge conv-badge--fail"
-                  title="归档失败"
-                  >败</span
+                  v-if="item.archiveOutcome"
+                  class="conv-badge conv-badge--archive"
+                  :class="archiveConvBadgeClass(item.archiveOutcome)"
+                  :title="archiveConvBadgeTitle(item.archiveOutcome)"
+                  >{{ archiveConvBadgeText(item.archiveOutcome) }}</span
                 >
               </span>
             </el-tooltip>
@@ -1851,8 +1840,30 @@ const archiveOutcomeTag = computed(() => {
   if (o === 'involved') {
     return { label: '介入归档', type: 'warning', outcomeClass: 'is-involved', ok: false }
   }
-  return { label: '成功', type: 'success', outcomeClass: 'is-ok', ok: true }
+  return { label: '正常归档', type: 'success', outcomeClass: 'is-ok', ok: true }
 })
+
+/** 侧栏已归档会话角标（强调「归档」，不用易误解的「成」） */
+function archiveConvBadgeText(outcome) {
+  if (outcome === 'failed') return '失败'
+  if (outcome === 'involved') return '介入'
+  if (outcome === 'success') return '归档'
+  return ''
+}
+
+function archiveConvBadgeTitle(outcome) {
+  if (outcome === 'failed') return '已归档 · 归档失败'
+  if (outcome === 'involved') return '已归档 · 介入归档（含失败步骤或人工放行）'
+  if (outcome === 'success') return '已归档 · 正常结束'
+  return ''
+}
+
+function archiveConvBadgeClass(outcome) {
+  if (outcome === 'failed') return 'conv-badge--fail'
+  if (outcome === 'involved') return 'conv-badge--involved'
+  if (outcome === 'success') return 'conv-badge--ok'
+  return ''
+}
 
 /** 群报告：启动说明 */
 const announceKickoff = computed(() => {
@@ -3449,16 +3460,23 @@ loadLists().then(() => {
 }
 .conv-badge {
   flex-shrink: 0;
-  width: 16px;
+  box-sizing: border-box;
+  min-width: 16px;
   height: 16px;
+  padding: 0 4px;
   border-radius: 5px;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
   line-height: 16px;
   text-align: center;
   letter-spacing: 0;
   color: #fff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+.conv-badge--archive {
+  max-width: 36px;
+  overflow: hidden;
+  white-space: nowrap;
 }
 .conv-badge--ok {
   background: linear-gradient(145deg, #85ce61, #67c23a);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景
全部步骤完成并「已同意归档」时，顶栏仍可能因历史 `failed` 节点误显示「失败」；侧栏绿色「成」易被理解成任务成功而非**已归档**。

## 改动
- **顶栏**：`archive_reason` 判定真失败；含失败步骤的确认归档 →「介入归档」；顺利结束 →「正常归档」（不再用「成功」）。
- **侧栏角标**（已归档会话）：**归档**（绿）/ **介入**（橙）/ **失败**（红），悬停为「已归档 · …」。
- 角标支持两字宽度，避免单字「成/介/败」歧义。

## 文档
- `docs/data-storage.md` 归档确认补充侧栏角标说明。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

