### PR TITLE
feat(support): 微信二维码与收款码配置及展示

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,20 @@ WebSocket：`ws://127.0.0.1:3780/ws?sessionId=<id>`
 | 手机 | 17312678391 |
 | 微信 | 默认同手机号（可在 `server/config/support.json` 修改） |
 
+收款码与微信二维码图片放在 **`web/public/support/`**（构建后通过 `/support/…` 访问），配置见 `server/config/support.json` 的 `wechatQrPath`、`sponsorQrPaths`。
+
+| 文件 | 用途 |
+|------|------|
+| `wechat-pay.png` | 技术交流区「微信扫码」 |
+| `wechat-collect.png` | 点赞支持 · 微信零钱收款 |
+| `alipay-pay.png` | 点赞支持 · 支付宝 |
+
+<p align="center">
+  <img src="web/public/support/wechat-pay.png" alt="微信支付" width="200" />
+  <img src="web/public/support/wechat-collect.png" alt="微信收款" width="200" />
+  <img src="web/public/support/alipay-pay.png" alt="支付宝" width="200" />
+</p>
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ WebSocket：`ws://127.0.0.1:3780/ws?sessionId=<id>`
 
 | 文件 | 用途 |
 |------|------|
-| `wechat-pay.png` | 技术交流区「微信扫码」 |
+| `wechat-pay.png` | 技术交流区「微信扫码」；点赞支持 · 微信支付 |
 | `wechat-collect.png` | 点赞支持 · 微信零钱收款 |
 | `alipay-pay.png` | 点赞支持 · 支付宝 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 | [brand-logo.md](./brand-logo.md) | **Logo 含义与资产** |
 | [directory-structure.md](./directory-structure.md) | 目录与模块边界（对齐代码） |
 | [author-contact.example.json](./author-contact.example.json) | 支持与交流配置示例 |
+| `../web/public/support/` | 微信二维码 / 收款码静态图（见根 [README](../README.md#支持与交流)） |
 
 ## 维护原则
 

--- a/docs/author-contact.example.json
+++ b/docs/author-contact.example.json
@@ -12,7 +12,8 @@
   "sponsorSubHint": "若你愿意，期待一点点小惊喜 ✨",
   "sponsorQrPaths": [
     "/support/wechat-collect.png",
+    "/support/wechat-pay.png",
     "/support/alipay-pay.png"
   ],
-  "sponsorQrLabels": ["微信零钱收款", "支付宝"]
+  "sponsorQrLabels": ["微信零钱收款", "微信支付", "支付宝"]
 }

--- a/docs/author-contact.example.json
+++ b/docs/author-contact.example.json
@@ -2,12 +2,17 @@
   "name": "",
   "phone": "17312678391",
   "wechat": "17312678391",
-  "wechatQrPath": "",
+  "wechatQrPath": "/support/wechat-pay.png",
+  "wechatQrLabel": "微信扫码（交流 / 收款）",
   "email": "",
   "links": [],
   "note": "欢迎技术交流与问题反馈。顺手点个赞，比什么都暖。",
   "sponsorTitle": "点赞支持",
   "sponsorHint": "完全自愿，不影响任何功能。",
   "sponsorSubHint": "若你愿意，期待一点点小惊喜 ✨",
-  "sponsorQrPaths": []
+  "sponsorQrPaths": [
+    "/support/wechat-collect.png",
+    "/support/alipay-pay.png"
+  ],
+  "sponsorQrLabels": ["微信零钱收款", "支付宝"]
 }

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -39,8 +39,9 @@ apple-co-work/
 │       └── seed.js              # 手动 seed 脚本
 │
 ├── web/                         # @acw/web — Vue3 前端
-│   ├── public/favicon.svg       # 标签页 Logo
-│   └── src/components/AppLogo.vue
+│   ├── public/
+│   │   ├── favicon.svg
+│   │   └── support/           # 微信/收款码（静态资源，/support/*.png）
 │   ├── package.json
 │   ├── vite.config.js           # host 127.0.0.1:5173；代理 /api、/ws → :3780
 │   ├── index.html

--- a/server/config/support.json
+++ b/server/config/support.json
@@ -12,7 +12,8 @@
   "sponsorSubHint": "若你愿意，期待一点点小惊喜 ✨",
   "sponsorQrPaths": [
     "/support/wechat-collect.png",
+    "/support/wechat-pay.png",
     "/support/alipay-pay.png"
   ],
-  "sponsorQrLabels": ["微信零钱收款", "支付宝"]
+  "sponsorQrLabels": ["微信零钱收款", "微信支付", "支付宝"]
 }

--- a/server/config/support.json
+++ b/server/config/support.json
@@ -2,12 +2,17 @@
   "name": "",
   "phone": "17312678391",
   "wechat": "17312678391",
-  "wechatQrPath": "",
+  "wechatQrPath": "/support/wechat-pay.png",
+  "wechatQrLabel": "微信扫码（交流 / 收款）",
   "email": "",
   "links": [],
   "note": "欢迎技术交流与问题反馈。顺手点个赞，比什么都暖。",
   "sponsorTitle": "点赞支持",
   "sponsorHint": "完全自愿，不影响任何功能。",
   "sponsorSubHint": "若你愿意，期待一点点小惊喜 ✨",
-  "sponsorQrPaths": []
+  "sponsorQrPaths": [
+    "/support/wechat-collect.png",
+    "/support/alipay-pay.png"
+  ],
+  "sponsorQrLabels": ["微信零钱收款", "支付宝"]
 }

--- a/web/src/views/settings/Support.vue
+++ b/web/src/views/settings/Support.vue
@@ -29,6 +29,10 @@
         <span>{{ data.wechat || '—' }}</span>
         <el-button v-if="data.wechat" link type="primary" @click="copy(data.wechat)">复制</el-button>
       </div>
+      <div v-if="data.wechatQrPath" class="wechat-qr-block">
+        <p class="qr-caption">{{ data.wechatQrLabel || '微信扫码' }}</p>
+        <img :src="data.wechatQrPath" class="qr-img qr-img--contact" alt="微信二维码" />
+      </div>
     </el-card>
 
     <el-card shadow="never" class="support-card support-card--like">
@@ -42,14 +46,11 @@
         {{ data.sponsorSubHint || '若你愿意，期待一点点小惊喜 ✨' }}
       </p>
 
-      <div v-if="data.sponsorQrPaths?.length" class="qr-list">
-        <img
-          v-for="(src, i) in data.sponsorQrPaths"
-          :key="i"
-          :src="src"
-          class="qr-img"
-          alt="支持码"
-        />
+      <div v-if="sponsorQrItems.length" class="qr-list">
+        <div v-for="(item, i) in sponsorQrItems" :key="i" class="qr-item">
+          <p v-if="item.label" class="qr-caption">{{ item.label }}</p>
+          <img :src="item.src" class="qr-img" :alt="item.label || '收款码'" />
+        </div>
       </div>
       <p v-else class="like-placeholder">
         心意通道稍后再开 · 先聊技术也完全 OK
@@ -59,11 +60,21 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { api } from '../../api'
 
 const data = ref({})
+
+const sponsorQrItems = computed(() => {
+  const paths = data.value.sponsorQrPaths
+  if (!Array.isArray(paths) || !paths.length) return []
+  const labels = data.value.sponsorQrLabels
+  return paths.map((src, i) => ({
+    src,
+    label: Array.isArray(labels) && labels[i] ? String(labels[i]) : '',
+  }))
+})
 
 function copy(t) {
   navigator.clipboard.writeText(t || '')
@@ -158,19 +169,39 @@ onMounted(async () => {
   line-height: 1.5;
 }
 
+.wechat-qr-block {
+  margin-top: 14px;
+}
+
+.qr-caption {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
 .qr-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 16px;
   margin-top: 14px;
+}
+
+.qr-item {
+  flex: 0 0 auto;
 }
 
 .qr-img {
   width: 148px;
-  height: 148px;
+  max-width: 100%;
+  height: auto;
+  max-height: 200px;
   object-fit: contain;
   border-radius: 12px;
   border: 1px solid var(--el-border-color-lighter);
   background: #fff;
+}
+
+.qr-img--contact {
+  max-height: 220px;
 }
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 说明
- **设置 → 支持与交流**：技术交流区展示 `wechatQrPath`；点赞支持区展示带标题的收款码列表。
- 配置：`server/config/support.json`（与 `docs/author-contact.example.json` 同步）。
- 静态资源目录：`web/public/support/`（访问路径 `/support/*.png`）。
- 根 [README](README.md#支持与交流) 增加收款码说明与文档内嵌图。
- **点赞支持**已配置三张图：微信零钱收款、微信支付、支付宝。

## 待补图
请把三张图放入 `web/public/support/`：`wechat-collect.png`、`wechat-pay.png`、`alipay-pay.png`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

