### PR TITLE
fix(ui): 右栏流程/群报告/资源 Tab 滚动固定

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -83,7 +83,7 @@ body,
 .hide-scrollbar,
 .wb-left,
 .wb-conv-wrap,
-.wb-right,
+.wb-right-pane,
 .wb-chat-scroll,
 .settings-body {
   scrollbar-width: none;
@@ -93,7 +93,7 @@ body,
 .hide-scrollbar::-webkit-scrollbar,
 .wb-left::-webkit-scrollbar,
 .wb-conv-wrap::-webkit-scrollbar,
-.wb-right::-webkit-scrollbar,
+.wb-right-pane::-webkit-scrollbar,
 .wb-chat-scroll::-webkit-scrollbar,
 .settings-body::-webkit-scrollbar,
 .wb-conv-wrap :deep(*::-webkit-scrollbar),
@@ -228,7 +228,7 @@ body,
   z-index: 1;
 }
 
-/* 右栏：流程轨 */
+/* 右栏：流程轨（Tab 固定，仅内容区滚动） */
 .wb-right {
   width: var(--ecw-rail-w);
   min-width: var(--ecw-rail-w);
@@ -239,9 +239,11 @@ body,
   backdrop-filter: saturate(160%) blur(40px);
   -webkit-backdrop-filter: saturate(160%) blur(40px);
   box-shadow: var(--ecw-shadow-md);
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding: 20px 16px 26px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  padding: 16px 16px 18px;
 }
 
 /* 侧栏顶区 */

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -4703,11 +4703,12 @@ loadLists().then(() => {
 .wb-right-tabs {
   display: flex;
   gap: 4px;
-  margin: 0 0 14px;
+  margin: 0 0 12px;
   padding: 3px;
   border-radius: 10px;
   background: rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 0.5px 1px rgba(0, 0, 0, 0.04);
+  flex-shrink: 0;
 }
 
 .wb-right-tab {
@@ -4752,17 +4753,23 @@ loadLists().then(() => {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-height: 0;
 }
 .resources-note {
   margin: 0;
   font-size: 11.5px;
   line-height: 1.45;
   color: var(--ecw-text-3, #8b8f9a);
+  flex-shrink: 0;
 }
 .resources-body {
   display: flex;
   flex-direction: column;
   gap: 14px;
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 .resources-block-title {
   display: flex;
@@ -4815,7 +4822,17 @@ loadLists().then(() => {
 }
 
 .wb-right-pane {
+  flex: 1;
   min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.wb-right-pane.announce-pane,
+.wb-right-pane.resources-pane {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .announce-pane {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
右侧「流程 / 群报告 / 资源」Tab 与下方列表同属 `.wb-right` 的滚动容器，长流程图滚动时 Tab 一起被卷走。

## 改动
- `.wb-right` 改为纵向 flex + `overflow: hidden`，Tab 区 `flex-shrink: 0`
- **流程**：`.wb-right-pane` 单独 `overflow-y: auto`
- **群报告**：沿用工具栏 + `announce-card` 内滚动（pane 不再整体滚动）
- **资源**：工具栏与说明固定，`resources-body` 内滚动

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

