### PR TITLE
feat(archive): 轻量待归档与流程轨确认按钮

### DIFF
--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -92,7 +92,7 @@ apple-co-work/
 | **#群聊** | 整份群模板名片（开聊即生成，不依赖用户输入） |
 | **#文件夹** | 群聊工作文件夹绝对/配置路径（开聊即写入） |
 | **群报告 ANNOUNCEMENT.md** | **# 参数全集**（`#群聊` / `#文件夹` / `#1`…）+ **各子节点输入/输出**；人工可 PUT 编辑；手改后 `announcementManual=true`，自动汇总不覆盖除非 force；路径仍为 `journals/sessions/{sessionId}/ANNOUNCEMENT.md`（文件名兼容） |
-| **归档确认** | 完成/失败/拒绝后进入 `pendingArchive`（**不立刻归档**）；待确认时只杀非 `detach` 进程（Cursor CLI 等仅唤起窗口保留）；手工「归档」/闸门同意，或超时（默认 **3h**，`autoArchiveHours`）→ `archiveSession`：**必杀本会话全部进程**（含 detach）；`archive_reason` 区分结果（`failed`/`rejected`→失败，其余→成功） |
+| **归档确认** | 流程跑完后写 `pendingArchive`，会话仍为 **active**；右侧流程轨「归档」步展示 **确认 / 确认并归档** 与自动归档倒计时（默认 **3h** `autoArchiveHours`）；末步人工闸门可 **确认** 或 **确认并归档**；顶栏「归档」随时可释资源；超时 `archiveSession` 必杀含 detach 进程 |
 | **审核三态** | 节点 `output.humanAction`：`pending` / `approve` / `reject`；脚本产出或输入框消息保持 `pending`；仅闸门「同意/拒绝」改态并推进 |
 | **归档 / 解档 / 再发** | **已决**：归档只释资源；再发仍在本会话、不新开群聊；可无限归档；续跑=本会话追加克隆节点。详见 [mvp.md §1.0](./mvp.md) 与 `SESSION_ARCHIVE_RULES`。 |
 | **从节点重开** | `POST /sessions/:id/restart-from-node`：本会话线性追加克隆并开跑（场外无此操作）；已归档则先解档 |

--- a/server/src/engine.js
+++ b/server/src/engine.js
@@ -180,6 +180,22 @@ export function ensureArchiveTailNode(sessionId, { title } = {}) {
   return db.prepare('SELECT * FROM node_instances WHERE id = ?').get(id)
 }
 
+function getNextNodeInstance(sessionId, node) {
+  if (!sessionId || !node) return null
+  const nextIdx = Number(node.step_index) + 1
+  if (!Number.isFinite(nextIdx)) return null
+  return getDb()
+    .prepare(
+      `SELECT * FROM node_instances WHERE session_id = ? AND step_index = ? LIMIT 1`,
+    )
+    .get(sessionId, nextIdx)
+}
+
+function isNodeBeforeArchiveTail(sessionId, node) {
+  const next = getNextNodeInstance(sessionId, node)
+  return next?.step_type === STEP_TYPE.ARCHIVE
+}
+
 function markArchiveNodeDone(sessionId, { reason, note } = {}) {
   const node = getDb()
     .prepare(
@@ -1887,8 +1903,9 @@ export function requestArchiveConsent(sessionId, reason = 'completed') {
     hours,
     nodeInstanceId: archNode.id,
   }
+  // 轻量待归档：会话保持 active，操作集中在流程轨末步，不再弹 chat 归档闸门
   updateSession(sessionId, {
-    status: SESSION_STATUS.WAITING_HUMAN,
+    status: SESSION_STATUS.ACTIVE,
     current_step_index: Number(archNode.step_index),
     context_json: JSON.stringify(ctx),
   })
@@ -1907,6 +1924,7 @@ export function requestArchiveConsent(sessionId, reason = 'completed') {
       reason,
       hours,
       dueAt: dueAt.toISOString(),
+      lightArchive: true,
     },
     status: NODE_STATUS.WAITING_HUMAN,
   })
@@ -1932,38 +1950,15 @@ export function requestArchiveConsent(sessionId, reason = 'completed') {
     type: 'status',
     node_instance_id: archNode.id,
     content: {
-      text: `${reasonLabel}。请在右侧「归档」节点确认；也可手动归档。${hours} 小时内未确认将自动归档（尽量结束进程并放开目录）。超时可在设置里改。`,
-    },
-  })
-  addMessage(sessionId, {
-    role: 'system',
-    type: 'gate',
-    node_instance_id: archNode.id,
-    content: {
-      mode: 'archive_confirm',
-      text: `${reasonLabel}。是否确认归档？`,
-      reason,
-      dueAt: dueAt.toISOString(),
-      hours,
-      actions: ['approve_archive', 'defer_archive'],
-      policy: `同意=立即归档；暂不归档=仍保留任务，但满 ${hours} 小时后仍会自动归档（设置 → 偏好可改）。`,
-    },
-  })
-  emitSession(sessionId, {
-    type: 'gate.request',
-    payload: {
-      mode: 'archive_confirm',
-      dueAt: dueAt.toISOString(),
-      hours,
-      reason,
-      nodeInstanceId: archNode.id,
+      text: `${reasonLabel}。请在右侧流程「归档」处点「确认并归档」或「确认」；顶栏亦可手动归档。约 ${hours} 小时后自动归档（设置 → 偏好可改）。`,
+      pendingArchive: ctx.pendingArchive,
     },
   })
   emitSession(sessionId, {
     type: 'session.status',
     payload: {
       sessionId,
-      status: SESSION_STATUS.WAITING_HUMAN,
+      status: SESSION_STATUS.ACTIVE,
       pendingArchive: ctx.pendingArchive,
       currentStepIndex: Number(archNode.step_index),
     },
@@ -1977,8 +1972,8 @@ export function requestArchiveConsent(sessionId, reason = 'completed') {
  */
 export function processDueArchives() {
   const rows = getDb()
-    .prepare(`SELECT * FROM sessions WHERE status = ?`)
-    .all(SESSION_STATUS.WAITING_HUMAN)
+    .prepare(`SELECT * FROM sessions WHERE status != ?`)
+    .all(SESSION_STATUS.ARCHIVED)
   const archived = []
   const now = Date.now()
   for (const row of rows) {
@@ -2454,13 +2449,13 @@ export async function resolveInterruptedSession(sessionId, action) {
 
   if (ctx.pendingArchive) {
     updateSession(sessionId, {
-      status: SESSION_STATUS.WAITING_HUMAN,
+      status: SESSION_STATUS.ACTIVE,
       context_json: JSON.stringify(ctx),
     })
     addMessage(sessionId, {
       role: 'system',
       type: 'status',
-      content: { text: '已恢复到归档确认，请继续操作。' },
+      content: { text: '已恢复；待归档请在右侧流程轨操作。' },
     })
     return { ok: true, resumed: true, pendingArchive: true }
   }
@@ -2750,7 +2745,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
           role: 'user',
           type: 'gate',
           content: {
-            text: archNote ? `暂不归档：${archNote}` : '暂不归档',
+            text: archNote ? `确认（暂不立即归档）：${archNote}` : '确认（暂不立即归档）',
             action: 'defer_archive',
             mode: 'archive_confirm',
             note: archNote || undefined,
@@ -2762,7 +2757,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
           c.userNotes.push({
             at: nowIso(),
             action: 'defer_archive',
-            actionLabel: '暂不归档',
+            actionLabel: '确认',
             text: archNote,
           })
           updateSession(sessionId, { context_json: JSON.stringify(c) })
@@ -3030,7 +3025,8 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
     return { ok: true, submitted: true }
   }
 
-  if (action === 'approve' || action === 'admin_approve') {
+  if (action === 'approve' || action === 'admin_approve' || action === 'approve_and_archive') {
+    const archiveAfterPass = action === 'approve_and_archive'
     const out = parseJson(node.output_json, {})
     // 兼容旧会话遗留的 path_busy 闸门：同意 = 直接重试执行（已不再互斥拦截）
     if (out.code === 'PATH_BUSY' || out.pathBusy) {
@@ -3076,8 +3072,8 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
     const flow = normalizeStepFlow(out.flow, node.gate)
     const { note } = bindGateHumanInput(sessionId, {
       text,
-      action: 'approve',
-      actionLabel: '同意',
+      action: archiveAfterPass ? 'approve_and_archive' : 'approve',
+      actionLabel: archiveAfterPass ? '确认并归档' : '同意',
       nodeTitle: node.title || `步骤 ${Number(node.step_index) + 1}`,
       nodeInstanceId: node.id,
     })
@@ -3101,14 +3097,20 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
       ? !!votes.human
       : !!(votes.human || votes.admin)
 
-    const baseLabel = action === 'admin_approve' ? '管理员已同意' : '已同意'
+    const baseLabel = archiveAfterPass
+      ? '确认并归档'
+      : action === 'admin_approve'
+        ? '管理员已同意'
+        : isNodeBeforeArchiveTail(sessionId, node)
+          ? '确认'
+          : '已同意'
     addMessage(sessionId, {
       role: 'user',
       type: 'gate',
       node_instance_id: node.id,
       content: {
         text: note ? `${baseLabel}：${note}` : baseLabel,
-        action: 'approve',
+        action: archiveAfterPass ? 'approve_and_archive' : 'approve',
         note: note || undefined,
         votes,
       },
@@ -3155,6 +3157,24 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId })
       status: SESSION_STATUS.ACTIVE,
       current_step_index: node.step_index + 1,
     })
+    if (archiveAfterPass && isNodeBeforeArchiveTail(sessionId, node)) {
+      setImmediate(async () => {
+        try {
+          await advance(sessionId)
+          const live = getSession(sessionId)
+          if (!live || live.status === SESSION_STATUS.ARCHIVED) return
+          const ctxA = parseJson(live.context_json, {})
+          const r = ctxA.pendingArchive?.reason || 'completed'
+          archiveSession(
+            sessionId,
+            r === 'completed' ? 'completed_confirmed' : r,
+          )
+        } catch (e) {
+          console.error('[acw] approve_and_archive failed', e?.message || e)
+        }
+      })
+      return { ok: true, passed: true, archivedAfterPass: true }
+    }
     setImmediate(() => advance(sessionId).catch(console.error))
     return { ok: true, passed: true }
   }

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -309,8 +309,8 @@
                             ? '请输入'
                             : pendingGate.content?.mode === 'interrupted'
                               ? '崩溃恢复'
-                              : pendingGate.content?.mode === 'archive_confirm'
-                                ? '确认归档'
+                              : isLastStepBeforeArchiveGate(pendingGate)
+                                ? '最后一步'
                                 : pendingGate.content?.requireHuman
                                   ? '须人工同意'
                                   : '待你处理'
@@ -319,19 +319,7 @@
                   <!-- 说明 + 操作；文字统一走下方消息输入框 -->
                   <div class="gate-scroll">
                     <div class="gate-title">{{ pendingGate.content?.text }}</div>
-                    <p
-                      v-if="
-                        pendingGate.content?.mode === 'archive_confirm' &&
-                        pendingGate.content?.dueAt
-                      "
-                      class="gate-policy"
-                    >
-                      截止：{{ formatDueAt(pendingGate.content.dueAt) }}（{{
-                        pendingGate.content.hours || autoArchiveHours
-                      }}
-                      小时内未确认将自动归档）
-                    </p>
-                    <p v-else-if="pendingGate.content?.policy" class="gate-policy">
+                    <p v-if="pendingGate.content?.policy" class="gate-policy">
                       {{ pendingGate.content.policy }}
                     </p>
                     <p
@@ -557,14 +545,6 @@
                             提交
                           </el-button>
                         </template>
-                        <template v-else-if="pendingGate.content?.mode === 'archive_confirm'">
-                          <el-button type="danger" @click="gate(pendingGate, 'approve_archive')">
-                            同意归档
-                          </el-button>
-                          <el-button plain @click="gate(pendingGate, 'defer_archive')">
-                            暂不归档
-                          </el-button>
-                        </template>
                         <template v-else-if="pendingGate.content?.mode === 'interrupted'">
                           <el-button type="danger" @click="gate(pendingGate, 'resume_interrupted')">
                             继续
@@ -577,8 +557,18 @@
                           </el-button>
                         </template>
                         <template v-else>
-                          <el-button type="danger" @click="gate(pendingGate, 'approve')">
-                            同意
+                          <el-button
+                            type="primary"
+                            @click="gate(pendingGate, 'approve')"
+                          >
+                            {{ isLastStepBeforeArchiveGate(pendingGate) ? '确认' : '同意' }}
+                          </el-button>
+                          <el-button
+                            v-if="isLastStepBeforeArchiveGate(pendingGate)"
+                            plain
+                            @click="gate(pendingGate, 'approve_and_archive')"
+                          >
+                            确认并归档
                           </el-button>
                           <el-button plain @click="gate(pendingGate, 'reject')">
                             拒绝
@@ -692,6 +682,19 @@
         <p v-else-if="offsiteActive" class="flow-offsite-hint">
           临时协助进行中
         </p>
+        <div v-else-if="pendingArchiveUi" class="flow-pending-archive">
+          <el-tooltip :content="archiveCountdownTooltip" placement="bottom">
+            <span class="flow-pending-archive-countdown">{{ archiveCountdownLabel }}</span>
+          </el-tooltip>
+          <div class="flow-pending-archive-actions">
+            <el-button size="small" type="primary" @click="flowArchiveAction('approve_archive')">
+              确认并归档
+            </el-button>
+            <el-button size="small" plain @click="flowArchiveAction('defer_archive')">
+              确认
+            </el-button>
+          </div>
+        </div>
         <template v-if="detail?.nodes?.length">
           <div
             v-for="n in detail.nodes"
@@ -833,8 +836,20 @@
                 </div>
               </button>
               <div class="flow-step-actions">
-                <template v-if="n.step_type === 'offsite' || n.step_type === 'archive'">
-                  <!-- 说明集中在输入区归档提示；此处不重复上课 -->
+                <template v-if="n.step_type === 'archive' && pendingArchiveUi">
+                  <el-button
+                    size="small"
+                    type="primary"
+                    @click.stop="flowArchiveAction('approve_archive')"
+                  >
+                    确认并归档
+                  </el-button>
+                  <el-button size="small" plain @click.stop="flowArchiveAction('defer_archive')">
+                    确认
+                  </el-button>
+                </template>
+                <template v-else-if="n.step_type === 'offsite' || n.step_type === 'archive'">
+                  <!-- 归档操作见上方待归档条 / 末步闸门 -->
                 </template>
                 <el-button
                   v-else
@@ -872,18 +887,29 @@
                 ? offsiteMode === 'planned'
                   ? '临时协助'
                   : '临时协助'
-                : needsHuman
-                  ? '待确认'
-                  : '当前节点'
+                : pendingArchiveUi
+                  ? '待归档'
+                  : needsHuman
+                    ? '待确认'
+                    : '当前节点'
             }}</span>
             <strong>
               {{
                 offsiteActive
                   ? activeOffsiteNode?.title || '临时协助'
-                  : detail.nodes.find((n) => isCurrent(n))?.title ||
-                    (detail.session.status === 'archived' ? '已归档（可重开）' : '—')
+                  : pendingArchiveUi
+                    ? '归档'
+                    : detail.nodes.find((n) => isCurrent(n))?.title ||
+                      (detail.session.status === 'archived' ? '已归档（可重开）' : '—')
               }}
             </strong>
+            <el-tooltip
+              v-if="pendingArchiveUi"
+              :content="archiveCountdownTooltip"
+              placement="top"
+            >
+              <span class="flow-current-archive-hint">{{ archiveCountdownLabel }}</span>
+            </el-tooltip>
           </div>
         </template>
         <div v-else class="flow-empty">
@@ -1580,24 +1606,7 @@ const pendingGate = computed(() => {
     const ig = msgs.find((m) => m.type === 'gate' && m.content?.mode === 'interrupted')
     if (ig) return ig
   }
-  // 归档确认闸门（绑定末尾归档节点）
-  const pendingArch = detail.value.session.context?.pendingArchive
-  if (pendingArch && detail.value.session.status !== 'interrupted') {
-    const archGate = msgs.find(
-      (m) => m.type === 'gate' && m.content?.mode === 'archive_confirm',
-    )
-    if (archGate) {
-      return {
-        ...archGate,
-        node_instance_id: archGate.node_instance_id || pendingArch.nodeInstanceId || null,
-        content: {
-          ...archGate.content,
-          dueAt: archGate.content.dueAt || pendingArch.dueAt,
-          hours: archGate.content.hours || pendingArch.hours,
-        },
-      }
-    }
-  }
+  // 待归档改在流程轨操作，不再占用输入区闸门
   // 优先当前游标节点上的待确认闸门，避免旧「待确认」抢交互
   if (curNode?.status === 'waiting_human') {
     const curGate = msgs.find(
@@ -1621,9 +1630,75 @@ const pendingGate = computed(() => {
 })
 
 const autoArchiveHours = computed(() => {
-  // 从最近 gate 或默认 3
-  return pendingGate.value?.content?.hours || 3
+  return pendingArchiveUi.value?.hours || sessionCtx()?.pendingArchive?.hours || 3
 })
+
+/** 轻量待归档（流程轨展示倒计时与按钮） */
+const pendingArchiveUi = computed(() => {
+  const s = detail.value?.session
+  if (!s || s.status === 'archived') return null
+  const pa = sessionCtx()?.pendingArchive
+  if (!pa?.dueAt) return null
+  return pa
+})
+
+const archiveNow = ref(Date.now())
+let archiveTickTimer = null
+
+watch(
+  pendingArchiveUi,
+  (pa) => {
+    if (archiveTickTimer) {
+      clearInterval(archiveTickTimer)
+      archiveTickTimer = null
+    }
+    if (pa) {
+      archiveNow.value = Date.now()
+      archiveTickTimer = setInterval(() => {
+        archiveNow.value = Date.now()
+      }, 30000)
+    }
+  },
+  { immediate: true },
+)
+
+const archiveCountdownLabel = computed(() => {
+  const due = pendingArchiveUi.value?.dueAt
+  if (!due) return ''
+  const ms = Math.max(0, new Date(due).getTime() - archiveNow.value)
+  if (ms <= 0) return '即将自动归档'
+  const h = Math.floor(ms / 3600000)
+  const m = Math.ceil((ms % 3600000) / 60000)
+  if (h > 0) return `约 ${h} 小时 ${m} 分后自动归档`
+  return `约 ${m} 分钟后自动归档`
+})
+
+const archiveCountdownTooltip = computed(() => {
+  const pa = pendingArchiveUi.value
+  if (!pa) return ''
+  const due = pa.dueAt ? formatDueAt(pa.dueAt) : '—'
+  const h = pa.hours ?? autoArchiveHours.value
+  return `未点「确认并归档」时，至 ${due} 将自动归档并释放进程（默认 ${h} 小时，可在设置 → 偏好修改）。「确认」= 暂不立即归档，会话可继续续聊。`
+})
+
+function isLastStepBeforeArchiveGate(m) {
+  if (!m?.node_instance_id || !detail.value?.nodes) return false
+  const node = detail.value.nodes.find((n) => n.id === m.node_instance_id)
+  if (!node || node.step_type === 'archive') return false
+  const nodes = [...detail.value.nodes].sort((a, b) => a.step_index - b.step_index)
+  const i = nodes.findIndex((n) => n.id === node.id)
+  if (i < 0) return false
+  return nodes[i + 1]?.step_type === 'archive'
+}
+
+async function flowArchiveAction(action) {
+  const pa = pendingArchiveUi.value
+  if (!pa || gating.value) return
+  await gate(
+    { node_instance_id: pa.nodeInstanceId, content: { mode: 'archive_confirm' } },
+    action,
+  )
+}
 
 function formatDueAt(iso) {
   if (!iso) return '—'
@@ -1969,7 +2044,9 @@ const composerPlaceholder = computed(() => {
   if (mode === 'interrupted') {
     return '服务曾中断：点右侧「继续 / 归档 / 放弃」（输入框可选附言）'
   }
-  if (mode === 'archive_confirm') return '在此写归档说明（可空），再点右侧按钮…'
+  if (isLastStepBeforeArchiveGate(g)) {
+    return '可先写附言；点「确认」或「确认并归档」…'
+  }
   return '可先写意见，再点「同意」或「拒绝」…'
 })
 
@@ -3220,7 +3297,8 @@ async function gate(m, action) {
     await loadDetail(activeId.value)
     sessions.value = await api.sessions.list()
     if (action === 'approve_archive') ElMessage.success('已归档')
-    else if (action === 'defer_archive') ElMessage.info('已暂不归档，超时仍将自动归档')
+    else if (action === 'defer_archive') ElMessage.info('已确认，会话可继续；超时仍将自动归档')
+    else if (action === 'approve_and_archive') ElMessage.success('已确认并归档')
     else if (action === 'approve_start') ElMessage.success('已通过，开始执行')
     else if (action === 'cancel_start') ElMessage.info('已取消，任务关闭')
     else if (action === 'resume_interrupted') ElMessage.success('已继续')
@@ -3310,6 +3388,7 @@ async function doDelete(targetId) {
 
 onUnmounted(() => {
   window.clearTimeout(flowScrollTimer)
+  if (archiveTickTimer) clearInterval(archiveTickTimer)
   if (ws) ws.close()
 })
 
@@ -5162,6 +5241,39 @@ loadLists().then(() => {
   font-size: 11.5px;
   color: #9a6414;
   line-height: 1.45;
+}
+.flow-pending-archive {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(230, 162, 60, 0.1);
+  border: 0.5px solid rgba(230, 162, 60, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.flow-pending-archive-countdown {
+  font-size: 12px;
+  font-weight: 600;
+  color: #9a6414;
+  cursor: help;
+  line-height: 1.45;
+}
+.flow-pending-archive-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.flow-current-bar .flow-current-archive-hint {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 550;
+  color: #9a6414;
+  cursor: help;
+  white-space: nowrap;
+  max-width: 48%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .flow-offsite-action-tip {
   font-size: 11px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更
- **待归档**：`requestArchiveConsent` 不再把会话置为 `waiting_human`，不再发 `archive_confirm` 聊天闸门；仅一条 system 状态 + `pendingArchive`。
- **流程轨**：顶部待归档条 + 当前节点条展示 **约 X 后自动归档**（hover 含截止时间与设置说明）；归档步 **确认 / 确认并归档**。
- **末步人工闸门**：**确认**（通过后进入待归档）/ **确认并归档**（通过并立即归档）/ **拒绝**。
- **自动归档**：`processDueArchives` 扫描所有未归档且 `pendingArchive.dueAt` 已到的会话（不限于 waiting_human）。
- 顶栏 **归档** 与 `autoArchiveHours` 行为不变。

## 文档
- `docs/data-storage.md` 归档确认一行更新。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

