### PR TITLE
Set up Cloud Agent dev environment + fix empty-DB seed crash

### DIFF
--- a/scripts/selftest-v1-priority.mjs
+++ b/scripts/selftest-v1-priority.mjs
@@ -46,6 +46,7 @@ async function main() {
         script: {
           mode: 'command',
           command: process.platform === 'win32' ? 'echo CI01-#1' : 'echo CI01-#1',
+          scriptWorkDir: process.cwd(),
           timeoutMs: 30_000,
           showScriptPopup: false,
         },

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -67,6 +67,8 @@ if (nonAdmin.length === 0) {
           process.platform === 'win32'
             ? 'echo ECW-OK #1'
             : 'echo ECW-OK #1',
+        // 脚本工作目录为必填项（见 assertScriptWorkDirConfigured）
+        scriptWorkDir: process.cwd(),
         timeoutMs: 600_000,
       },
     },

--- a/server/src/seed.js
+++ b/server/src/seed.js
@@ -28,6 +28,8 @@ const scriptCmd = createMember({
       mode: 'command',
       command: process.platform === 'win32' ? 'echo ECW-OK & cd' : 'echo ECW-OK && pwd',
       shell: 'cmd',
+      // 脚本工作目录为必填项（见 assertScriptWorkDirConfigured）
+      scriptWorkDir: process.cwd(),
       timeoutMs: 600_000,
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述 / Summary

为 `oh-my-co-work` 配置 Cloud Agent 开发环境，并修复一个阻断首次启动的既有缺陷。

## 背景 / The bug

提交 `fd28d3d`（`feat: 脚本工作目录保存时必填校验`）让脚本成员的 `scriptWorkDir` 变为**必填**（`assertScriptWorkDirConfigured`），但演示数据 seed 没有同步更新（`main` 分支同样存在此问题）：

- `server/src/index.js` 空库自动 seed 创建 `script_cmd` 成员时未提供 `scriptWorkDir`
- `server/src/seed.js`（`npm run seed`）同样缺失
- `scripts/selftest-v1-priority.mjs` 自测夹具同样缺失

结果：任何**全新空库**首次启动 `npm run dev:server` / `npm run start:server` 都会在 seed 阶段抛出 `NO_SCRIPT_WORK_DIR` 崩溃，服务无法监听端口。

## 改动 / Changes

在三处补上 `scriptWorkDir: process.cwd()`（脚本成员必填项）：

- `server/src/index.js` — 空库自动 seed 的示例命令成员
- `server/src/seed.js` — 手动 seed 脚本
- `scripts/selftest-v1-priority.mjs` — 自测夹具

## 验证 / Validation

- `npm ci`（预编译 `better-sqlite3`，无需编译工具链）+ 二次运行幂等
- `npm run build -w web` 产出 `web/dist`
- API `:3780` 空库启动成功，自动 seed「演示流」（groups 1, members 3），`/api/health` = `ok`
- Vite 前端 `:5173` 200；`npm run start:server` 单端口 `:3780` 同时提供 API + 前端
- 全部自测通过：`selftest-session-ops`、`selftest-forward-jump`、`selftest-v1-priority`、`selftest-v1-stability`、`test-enter-send`（Playwright）
- 浏览器端到端跑通「演示流」闸门流程（命令步输出 `ECW-OK demo`）
- 全新 Cloud Agent（从环境构建启动、检出本分支）复验通过：空库 seed 不再崩溃

### 端到端演示 / End-to-end demo

[oh_my_co_work_demo_flow_end_to_end.mp4](https://cursor.com/agents/bc-12d446f3-e37c-4823-8f06-8a79dbdf50a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foh_my_co_work_demo_flow_end_to_end.mp4)

[演示流命令步输出 ECW-OK demo](https://cursor.com/agents/bc-12d446f3-e37c-4823-8f06-8a79dbdf50a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_flow_ecw_ok_output.webp)

## 环境配置 / Environment

已通过 Cloud Agent 环境面板提议保存（不随本 PR 提交 `.cursor/environment.json`）：

- `install`: `npm ci` + `npm run build -w web`
- `start`: `npm run start:server`（`:3780` 提供 API 与前端）

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12d446f3-e37c-4823-8f06-8a79dbdf50a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12d446f3-e37c-4823-8f06-8a79dbdf50a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

