### PR TITLE
fix: 本机打开不再误报拒绝非本机页面访问

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -26,6 +26,7 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 2026-08-18 | M | server/src/index.js | 增加 POST /api/bootstrap，确保浏览器带 Origin
 2026-08-18 | M | web/src/api.js | bootstrap 改 POST，避免 GET 不带 Origin 被拒
 2026-08-18 | M | server/test/localAccess.test.js | 覆盖无 Origin 的本机 Host 与跨站拒绝
+2026-08-18 | M | docs/data-storage.md | 同步 bootstrap 本机无 Origin 行为
 2026-08-18 | M | CODE_CHANGE.md | 追加本轮条目
 
 2026-08-18 | M | docs/data-and-ops.md | 修订记录补 2.4.0 / 2.5.0

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,12 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-18 | M | server/src/localAccess.js | 同源回环无 Origin 也可领令牌，跨站仍拒绝
+2026-08-18 | M | server/src/index.js | 增加 POST /api/bootstrap，确保浏览器带 Origin
+2026-08-18 | M | web/src/api.js | bootstrap 改 POST，避免 GET 不带 Origin 被拒
+2026-08-18 | M | server/test/localAccess.test.js | 覆盖无 Origin 的本机 Host 与跨站拒绝
+2026-08-18 | M | CODE_CHANGE.md | 追加本轮条目
+
 2026-08-18 | M | docs/data-and-ops.md | 修订记录补 2.4.0 / 2.5.0
 2026-08-18 | M | package.json / workspaces / package-lock.json / about.json | 版本 2.5.0 最终封板
 2026-08-18 | M | README.md / AGENT.md / docs/* | 发布线与路线图改为 2.5.0 封板

--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -48,7 +48,7 @@ oh-my-co-work/
 本机 API 默认只服务本机页面，避免任意网页跨站驱动 `/api` 或终端：
 
 - 启动时生成随机 `ACW_API_TOKEN`（也可用环境变量固定）。
-- `GET /api/bootstrap` 在可信 Origin 下下发令牌；前端 `web/src/api.js` 缓存后用于 REST 与 WebSocket。
+- `GET` / `POST /api/bootstrap` 在本机页面下发令牌；无 Origin 时只要 Host 是回环且不是跨站。前端 `web/src/api.js` 用 POST 领取后用于 REST 与 WebSocket。
 - CORS / Origin 仅允许 `127.0.0.1`、`localhost`、`::1`。
 - `/api/health` 免令牌；其余 `/api` 需要 `X-ACW-Token`、`Authorization: Bearer` 或 query `token`。
 - WebSocket `verifyClient` 同样校验 Origin 与 URL 中的 `token`。

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -133,6 +133,7 @@ app.use(
 )
 app.use(express.json({ limit: '2mb' }))
 app.get('/api/bootstrap', bootstrapLocalAccess)
+app.post('/api/bootstrap', bootstrapLocalAccess)
 app.use('/api', requireLocalAccess)
 app.use('/api', routes)
 

--- a/server/src/localAccess.js
+++ b/server/src/localAccess.js
@@ -8,19 +8,49 @@ function safeEqual(a, b) {
   return left.length === right.length && crypto.timingSafeEqual(left, right)
 }
 
+function hostnameOf(hostOrUrl) {
+  const raw = String(hostOrUrl || '').trim()
+  if (!raw || raw === 'null') return ''
+  try {
+    const url = raw.includes('://') ? new URL(raw) : new URL(`http://${raw}`)
+    return String(url.hostname || '').toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+export function isLoopbackHostname(host) {
+  const h = hostnameOf(host)
+  return h === '127.0.0.1' || h === 'localhost' || h === '::1' || h.endsWith('.localhost')
+}
+
 export function isTrustedOrigin(origin) {
   if (!origin) return true
   if (origin === 'null') return false
   try {
     const url = new URL(origin)
-    const host = url.hostname.toLowerCase()
     return (
       (url.protocol === 'http:' || url.protocol === 'https:') &&
-      (host === '127.0.0.1' || host === 'localhost' || host === '[::1]' || host === '::1')
+      isLoopbackHostname(url.hostname)
     )
   } catch {
     return false
   }
+}
+
+/** 本机页面发起的请求：可信 Origin，或同源回环且不是跨站。 */
+export function isTrustedLocalRequest(req) {
+  const origin = req?.headers?.origin
+  const host = req?.headers?.host
+  const site = String(req?.headers['sec-fetch-site'] || '').toLowerCase()
+  const referer = req?.headers?.referer
+
+  if (site === 'cross-site') return false
+  if (origin === 'null') return false
+  if (origin) return isTrustedOrigin(origin)
+  if (!isLoopbackHostname(host)) return false
+  if (referer && !isTrustedOrigin(referer)) return false
+  return true
 }
 
 export function rejectUntrustedOrigin(req, res, next) {
@@ -31,8 +61,7 @@ export function rejectUntrustedOrigin(req, res, next) {
 }
 
 export function bootstrapLocalAccess(req, res) {
-  const origin = req?.headers?.origin
-  if (!origin || !isTrustedOrigin(origin)) {
+  if (!isTrustedLocalRequest(req)) {
     return res.status(403).json({ error: '拒绝非本机页面访问' })
   }
   res.setHeader('Cache-Control', 'no-store')
@@ -62,4 +91,3 @@ export function requireLocalAccess(req, res, next) {
   }
   next()
 }
-

--- a/server/test/localAccess.test.js
+++ b/server/test/localAccess.test.js
@@ -38,6 +38,18 @@ test('bootstrap requires a trusted Origin and then issues a token', () => {
   bootstrapLocalAccess({ headers: { origin: 'https://example.com' } }, evil)
   assert.equal(evil.out.statusCode, 403)
 
+  const crossSite = jsonRes()
+  bootstrapLocalAccess(
+    { headers: { host: '127.0.0.1:3780', 'sec-fetch-site': 'cross-site' } },
+    crossSite,
+  )
+  assert.equal(crossSite.out.statusCode, 403)
+
+  const sameOriginNoHeader = jsonRes()
+  bootstrapLocalAccess({ headers: { host: '127.0.0.1:3780' } }, sameOriginNoHeader)
+  assert.equal(sameOriginNoHeader.out.statusCode, 200)
+  assert.ok(sameOriginNoHeader.out.body?.token)
+
   const ok = jsonRes()
   bootstrapLocalAccess({ headers: { origin: 'http://127.0.0.1:5173' } }, ok)
   assert.equal(ok.out.statusCode, 200)

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -3,7 +3,12 @@ let accessTokenPromise = null
 
 async function accessToken({ refresh = false } = {}) {
   if (refresh || !accessTokenPromise) {
-    accessTokenPromise = fetch(`${BASE}/bootstrap`, { cache: 'no-store' })
+    accessTokenPromise = fetch(`${BASE}/bootstrap`, {
+      method: 'POST',
+      cache: 'no-store',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: '{}',
+    })
       .then(async (res) => {
         const data = await res.json().catch(() => ({}))
         if (!res.ok || !data.token) throw new Error(data.error || '无法建立本地安全连接')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复本机打开后全部接口 403「拒绝非本机页面访问」，导致演示流、成员、手机号等看起来像消失。

部分浏览器对同源 GET `/api/bootstrap` 不带 `Origin`，服务端原先一律拒绝。现改为：

- 有 Origin：仍只允许 `127.0.0.1` / `localhost` / `::1`
- 无 Origin：Host 必须是回环，且 `Sec-Fetch-Site` 不能是 `cross-site`
- 前端改用 POST 领取令牌（更容易带上 Origin）

跨站页面仍然拿不到令牌。

## 验证

`npm test` 28 项通过（含无 Origin + 本机 Host、跨站拒绝）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd944de1-f0fa-454b-a897-aa3978686af4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd944de1-f0fa-454b-a897-aa3978686af4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

