### PR TITLE
fix(ui): 「需人工处理」徽标不换行

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,10 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-19 | M | web/src/views/Workbench.vue | 「需人工处理」徽标禁止换行，标题栏挤窄时让标题收缩
+2026-08-19 | M | CODE_CHANGE.md | 追加本轮条目
+
+
 2026-08-19 | M | README.md / AGENT.md | 首页口号与居中欢迎截图说明同步到 README
 2026-08-19 | M | Workbench.vue | 首页欢迎居中；口号同一字号颜色；补终端守护者/熔炉连接一切
 2026-08-19 | M | docs/brand-logo.md / frontend-components.md | 同步欢迎区文案与布局

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -3692,6 +3692,8 @@ loadLists().then(() => {
 .human-attention-pill {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
+  white-space: nowrap;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -3718,6 +3720,12 @@ loadLists().then(() => {
   align-items: center;
   gap: 12px;
   min-width: 0;
+  flex: 1;
+}
+
+.header-left :deep(.el-tag) {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .header-actions {
@@ -3728,6 +3736,8 @@ loadLists().then(() => {
 
 .title-input {
   width: min(380px, 46vw);
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .title-input :deep(.el-input__wrapper) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
会话中栏顶栏的红色「需人工处理」在窄宽度时会折成「需人工 / 处理」两行。

已给该徽标加上 `white-space: nowrap` 和 `flex-shrink: 0`，标题输入框改为可收缩，把空间让给状态标签和徽标。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2938f9e9-456c-47f8-abdc-757d283e1a2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2938f9e9-456c-47f8-abdc-757d283e1a2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

