### PR TITLE
fix: 顶栏删除聊天实际不生效

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,13 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-21 | M | web/src/views/Workbench.vue | 顶栏删除忽略 MouseEvent，只删当前会话 id，成功后清中间栏
+2026-08-21 | M | web/src/api.js | DELETE 会话路径 encodeURIComponent
+2026-08-21 | M | server/src/services.js | 会话不存在不假装删成功；空单聊临时群一并清掉
+2026-08-21 | M | server/src/routes.js | DELETE /sessions/:id 不存在返回 404
+2026-08-21 | M | server/test/memberReuse.test.js | 覆盖删除后不再复用旧会话
+2026-08-21 | M | CODE_CHANGE.md | 追加本轮条目
+
 2026-08-21 | M | packages/linux + win32 + darwin zip | 覆盖失败态 GUI 说明卡运行包
 2026-08-21 | M | FurnaceWorkspace.vue | 启动失败切回 GUI 说明卡，不再留空黑屏
 2026-08-21 | M | terminalService.js | spawn 失败写入 replay 和 lastError

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -413,10 +413,18 @@ router.post('/sessions/:id/pin', (req, res) => {
   }
 })
 router.delete('/sessions/:id', (req, res) => {
-  clearFurnaceInbox(req.params.id)
-  deleteSession(req.params.id)
-  forgetSessionTerminals(req.params.id)
-  res.status(204).end()
+  try {
+    const result = deleteSession(req.params.id)
+    if (!result?.deleted) {
+      res.status(404).json({ error: '会话不存在' })
+      return
+    }
+    clearFurnaceInbox(req.params.id)
+    forgetSessionTerminals(req.params.id)
+    res.status(204).end()
+  } catch (e) {
+    res.status(400).json({ error: e.message })
+  }
 })
 router.post('/sessions/:id/archive', (req, res) => {
   archiveSession(req.params.id, req.body?.reason || 'manual')

--- a/server/src/services.js
+++ b/server/src/services.js
@@ -481,14 +481,27 @@ export function saveSessionNotes(id, notes) {
 }
 
 export function deleteSession(id) {
+  const row = getDb().prepare('SELECT * FROM sessions WHERE id = ?').get(id)
+  if (!row) return { deleted: false }
   try {
     killSessionProcesses(id)
   } catch {
     /* ignore */
   }
-  getDb().prepare('DELETE FROM messages WHERE session_id = ?').run(id)
-  getDb().prepare('DELETE FROM node_instances WHERE session_id = ?').run(id)
-  getDb().prepare('DELETE FROM sessions WHERE id = ?').run(id)
+  const db = getDb()
+  db.prepare('DELETE FROM messages WHERE session_id = ?').run(id)
+  db.prepare('DELETE FROM node_instances WHERE session_id = ?').run(id)
+  db.prepare('DELETE FROM sessions WHERE id = ?').run(id)
+  if (row.group_id) {
+    const remaining = db.prepare('SELECT COUNT(*) AS c FROM sessions WHERE group_id = ?').get(row.group_id)
+    if (!remaining?.c) {
+      const g = getGroup(row.group_id)
+      if (g?.config?.adhoc) {
+        db.prepare('DELETE FROM groups WHERE id = ?').run(row.group_id)
+      }
+    }
+  }
+  return { deleted: true }
 }
 
 export {

--- a/server/test/memberReuse.test.js
+++ b/server/test/memberReuse.test.js
@@ -11,9 +11,8 @@ const { parseProjectParams, appendProjectParams, MAX_PROJECT_PARAMS, MEMBER_KIND
   await import('@acw/shared')
 const { initDb } = await import('../src/db.js')
 initDb()
-const { createMember, createSessionFromMember, getSessionDetail } = await import(
-  '../src/services.js'
-)
+const { createMember, createSessionFromMember, getSessionDetail, deleteSession, listGroups } =
+  await import('../src/services.js')
 
 test('project params cap at #99', () => {
   const many = Array.from({ length: 120 }, (_, i) => `p${i + 1}`).join(' ')
@@ -49,4 +48,29 @@ test('opening a member chat reuses the same session and skips start gate', async
   const second = createSessionFromMember(member.id)
   assert.equal(second.id, first.id)
   assert.equal(second.reused, true)
+})
+
+test('deleteSession actually removes the chat; missing id is not success', () => {
+  const member = createMember({
+    name: `echo-delete-${Date.now()}`,
+    displayName: '删除成员',
+    kind: MEMBER_KIND.ECHO,
+    workFolder: process.cwd(),
+    config: { defaultText: 'ok' },
+  })
+  const first = createSessionFromMember(member.id)
+  assert.ok(first?.id)
+  const gone = deleteSession(first.id)
+  assert.equal(gone.deleted, true)
+  assert.equal(getSessionDetail(first.id), null)
+  assert.equal(deleteSession(first.id).deleted, false)
+  const leftover = listGroups({ includeAdhoc: true, includeDemo: true }).filter(
+    (g) => g.config?.fromMemberId === member.id,
+  )
+  assert.equal(leftover.length, 0)
+
+  const again = createSessionFromMember(member.id)
+  assert.ok(again?.id)
+  assert.notEqual(again.id, first.id)
+  assert.equal(again.reused, undefined)
 })

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -66,7 +66,7 @@ export const api = {
     rename: (id, title) => req(`/sessions/${id}`, { method: 'PATCH', body: JSON.stringify({ title }) }),
     pin: (id, pinned = true) =>
       req(`/sessions/${id}/pin`, { method: 'POST', body: JSON.stringify({ pinned: !!pinned }) }),
-    remove: (id) => req(`/sessions/${id}`, { method: 'DELETE' }),
+    remove: (id) => req(`/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     archive: (id) => req(`/sessions/${id}/archive`, { method: 'POST', body: '{}' }),
     /** 恢复：仍在本会话，可无限归档 */
     unarchive: (id) => req(`/sessions/${id}/unarchive`, { method: 'POST', body: '{}' }),

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -185,7 +185,7 @@
             >
               {{ detail.session.pinned ? '取消置顶' : '置顶' }}
             </el-button>
-            <el-button size="default" text bg type="danger" @click="doDelete">删除</el-button>
+            <el-button size="default" text bg type="danger" @click="doDelete()">删除</el-button>
           </div>
         </div>
 
@@ -3498,9 +3498,14 @@ async function rename() {
   }
 }
 
+/** 只接受字符串会话 id。Vue 把 @click="doDelete" 的 MouseEvent 当第一参时必须忽略，否则会 DELETE /sessions/[object PointerEvent] */
+function resolveSessionId(targetId) {
+  return typeof targetId === 'string' && targetId ? targetId : activeId.value
+}
+
 /** @param {string} [targetId] 侧栏菜单可传指定会话 id；顶栏按钮不传则删当前 */
 async function doDelete(targetId) {
-  const id = targetId || activeId.value
+  const id = resolveSessionId(targetId)
   if (!id) {
     ElMessage.warning('没有可删除的会话')
     return
@@ -3514,11 +3519,14 @@ async function doDelete(targetId) {
   } catch {
     return
   }
+  const wasActive = activeId.value === id
   try {
     await api.sessions.remove(id)
-    if (activeId.value === id) {
+    await loadLists()
+    if (wasActive || activeId.value === id) {
       detail.value = null
-      activeId.value = null
+      terminalSessions.value = []
+      activeTerminalId.value = null
       if (ws) {
         try {
           ws.close()
@@ -3527,9 +3535,9 @@ async function doDelete(targetId) {
         }
         ws = null
       }
+      activeId.value = ''
       router.replace('/workbench')
     }
-    await loadLists()
     ElMessage.success('已删除')
   } catch (e) {
     ElMessage.error(e.message || '删除失败')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

工作台顶栏「删除」绑的是 `@click="doDelete"`。Vue 3 会把 **MouseEvent** 当成 `doDelete(targetId)` 的第一个参数。

于是请求变成 `DELETE /sessions/[object PointerEvent]`。后端即使 0 行也返回 **204**，界面 toast「已删除」，库里的「单熔」还在，中间栏也不清。

侧栏菜单走 `doDelete(id)` 传字符串，那条路径是对的。

## 修复

- 只接受字符串会话 id；顶栏改为 `@click="doDelete()"`
- 删成功后先刷新列表，再清空当前会话 / 终端 / WS，回到欢迎页
- `DELETE /sessions/:id` 会话不存在返回 **404**
- 单聊临时群若已无会话，一并删掉，避免空模板占着成员

## 验证

`npm test`（含 `deleteSession actually removes the chat`）通过。

排队里还有后续消息，本轮未打三平台 zip。Windows 运行包需合 main 后再 pack 才会带上此修复。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2938f9e9-456c-47f8-abdc-757d283e1a2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2938f9e9-456c-47f8-abdc-757d283e1a2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

