### PR TITLE
输入栏操作说明改为星号悬停提示

### DIFF
--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -521,7 +521,18 @@
                         class="file-input-hidden"
                         @change="onFileInputChange"
                       />
-                      <span class="composer-toolbar-hint">{{ composerToolbarHint }}</span>
+                      <span class="composer-toolbar-spacer"></span>
+                      <el-tooltip
+                        placement="top"
+                        :show-after="200"
+                        :content="composerToolbarHint"
+                      >
+                        <span
+                          class="composer-hint-star"
+                          role="img"
+                          :aria-label="composerToolbarHint"
+                        >*</span>
+                      </el-tooltip>
                       <div v-if="pendingGate" class="composer-gate-actions">
                         <template v-if="pendingGate.content?.mode === 'session_start'">
                           <el-button type="danger" @click="approveSessionStart(pendingGate)">
@@ -4642,11 +4653,31 @@ loadLists().then(() => {
   display: none;
 }
 
-.composer-toolbar-hint {
+.composer-toolbar-spacer {
   flex: 1;
   min-width: 0;
-  font-size: 11.5px;
-  color: var(--ecw-text-3, #8b8f9a);
+}
+
+.composer-hint-star {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  margin-right: 2px;
+  color: #e24b4a;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  user-select: none;
+  opacity: 0.72;
+  transition: opacity 0.15s ease;
+}
+
+.composer-hint-star:hover {
+  opacity: 1;
 }
 
 /* 附件区（参考 Plus-X 发送区附件卡片） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉输入工具栏里常显的灰条说明（如「Enter=发消息 · 点「通过」启动」），改成「通过 / 同意」按钮左侧的红色星号。悬停后仍能看到原来的操作说明，界面更干净。

文案逻辑未改，只换展示方式。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39e3c503-37ed-4bb6-8bc3-c1dbc140af55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39e3c503-37ed-4bb6-8bc3-c1dbc140af55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

