### PR TITLE
fix(ui): 输入栏操作说明改为星号悬停提示

### DIFF
--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -521,7 +521,18 @@
                         class="file-input-hidden"
                         @change="onFileInputChange"
                       />
-                      <span class="composer-toolbar-hint">{{ composerToolbarHint }}</span>
+                      <span class="composer-toolbar-spacer"></span>
+                      <el-tooltip
+                        placement="top"
+                        :show-after="200"
+                        :content="composerToolbarHint"
+                      >
+                        <span
+                          class="composer-hint-star"
+                          role="img"
+                          :aria-label="composerToolbarHint"
+                        >*</span>
+                      </el-tooltip>
                       <div v-if="pendingGate" class="composer-gate-actions">
                         <template v-if="pendingGate.content?.mode === 'session_start'">
                           <el-button type="danger" @click="approveSessionStart(pendingGate)">
@@ -4642,11 +4653,31 @@ loadLists().then(() => {
   display: none;
 }
 
-.composer-toolbar-hint {
+.composer-toolbar-spacer {
   flex: 1;
   min-width: 0;
-  font-size: 11.5px;
-  color: var(--ecw-text-3, #8b8f9a);
+}
+
+.composer-hint-star {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  margin-right: 2px;
+  color: #e24b4a;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  user-select: none;
+  opacity: 0.72;
+  transition: opacity 0.15s ease;
+}
+
+.composer-hint-star:hover {
+  opacity: 1;
 }
 
 /* 附件区（参考 Plus-X 发送区附件卡片） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
原先工具栏中间常显一整句灰字（如「Enter=发消息 · 点「通过」启动」），会挤占「通过 / 取消」按钮空间。

这次改成：

- 文案不再常显，改成「通过」按钮左侧的红色 `*` 标志
- 悬停星号才弹出原来的操作说明（含会话启动、提交参数、同意/拒绝等各闸门状态）
- 无障碍：`aria-label` 仍带完整说明

本地已用演示流开聊核对：闸门态工具栏只剩红色星号，悬停可见「Enter=发消息 · 点「通过」启动」。

没有改发送逻辑，只动输入工具栏展示。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1163ca3a-ea9c-4dfd-b293-2dd90a9918a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1163ca3a-ea9c-4dfd-b293-2dd90a9918a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

