### PR TITLE
fix(ui): 输入快捷说明改成 i 图标悬停

### DIFF
--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -46,7 +46,7 @@ app.use(ElementPlusX)
 | 中栏消息 | `BubbleList` | **`noStyle`** 去组件外壳；`#content` 内 `.bubble-rich` 单层气泡；`#header` 发送人、`#avatar` 首字 |
 | 终端消息 | `TerminalSessionCard` | 深灰玻璃终端卡；有限输出预览、运行态、进入终端与停止 |
 | 终端工作区 | `TerminalWorkspace` + `TerminalView` | 中栏占满；`xterm.js` 延迟加载，保留右侧流程轨；返回对话不停止进程 |
-| 中栏输入 | `XSender` | **`ref` 取文** + `@submit`；`@paste-file` 粘贴上传；`submit-type="enter"`；工具栏 `/` `@` `#` · 附件 · **复制**；Enter/闸门说明收成星号 `*`，悬停看全文 |
+| 中栏输入 | `XSender` | **`ref` 取文** + `@submit`；`@paste-file` 粘贴上传；`submit-type="enter"`；工具栏 `/` `@` `#` · 附件 · **复制**；Enter/闸门说明收成 **i** 图标，悬停看全文 |
 | 附件 | 自研 chip + 气泡 file-card | 先 `POST /sessions/:id/files`，再随消息 `attachments[]` |
 | Composer 面板 | 自研 slash / at / hash | `/` 指令；`@` 成员/节点；`#` → `#群聊`/`#文件夹`/`#1`…/`#出n` |
 | 未选会话 | 自研欢迎主视觉 | 居中：工具 Logo、一行口号（含终端守护者 / 熔炉连接一切）、一句说明、开聊按钮 |

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -528,10 +528,12 @@
                       >
                         <button
                           type="button"
-                          class="composer-kbd-star"
+                          class="composer-hint-i"
                           aria-label="输入快捷说明"
                         >
-                          *
+                          <el-icon :size="16" class="composer-hint-i-icon">
+                            <InfoFilled />
+                          </el-icon>
                         </button>
                       </el-tooltip>
                       <div v-if="pendingGate" class="composer-gate-actions">
@@ -1108,6 +1110,7 @@
 import { ref, computed, watch, onUnmounted, nextTick, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { InfoFilled } from '@element-plus/icons-vue'
 import {
   formatBusinessIo,
   digestBusinessIo,
@@ -4654,7 +4657,7 @@ loadLists().then(() => {
   display: none;
 }
 
-.composer-kbd-star {
+.composer-hint-i {
   flex: 1;
   display: inline-flex;
   align-items: center;
@@ -4665,15 +4668,15 @@ loadLists().then(() => {
   padding: 0 4px;
   border: 0;
   background: transparent;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1;
-  letter-spacing: 0;
   color: var(--ecw-text-3, #8b8f9a);
   cursor: help;
 }
 
-.composer-kbd-star:hover {
+.composer-hint-i-icon {
+  display: flex;
+}
+
+.composer-hint-i:hover {
   color: var(--ecw-text-2, #6e6e73);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
输入栏工具条上的操作说明不再用 `*` 星号，改成 Element Plus 的 **i**（`InfoFilled`）图标。悬停仍显示原来的 Enter / 闸门提示全文。

星号容易被理解成必填标记，和「说明」语义不符。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c32453a-3789-4e82-8d11-6e1819f4adf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c32453a-3789-4e82-8d11-6e1819f4adf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

