### PR TITLE
fix(ui): 输入说明改成圆形 i，不要星号

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,11 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-25 | M | Workbench.vue | 输入快捷说明改成圆形 i，贴在「通过」左侧
+2026-08-25 | M | frontend-components.md | 记圆形 i 悬停说明
+2026-08-25 | M | CODE_CHANGE.md | 追加本轮条目
+
+
 2026-08-25 | M | packages/linux + win32 + darwin zip | 覆盖输入框星号提示
 2026-08-25 | M | Workbench.vue | 工具栏「Enter=发消息」灰字改成星号，悬停看说明
 2026-08-25 | M | frontend-components.md | 记输入框星号提示

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -46,7 +46,7 @@ app.use(ElementPlusX)
 | 中栏消息 | `BubbleList` | **`noStyle`** 去组件外壳；`#content` 内 `.bubble-rich` 单层气泡；`#header` 发送人、`#avatar` 首字 |
 | 终端消息 | `TerminalSessionCard` | 深灰玻璃终端卡；有限输出预览、运行态、进入终端与停止 |
 | 终端工作区 | `TerminalWorkspace` + `TerminalView` | 中栏占满；`xterm.js` 延迟加载，保留右侧流程轨；返回对话不停止进程 |
-| 中栏输入 | `XSender` | **`ref` 取文** + `@submit`；`@paste-file` 粘贴上传；`submit-type="enter"`；工具栏 `/` `@` `#` · 附件 · **复制**；Enter/闸门说明收成 **i** 图标，悬停看全文 |
+| 中栏输入 | `XSender` | **`ref` 取文** + `@submit`；`@paste-file` 粘贴上传；`submit-type="enter"`；工具栏 `/` `@` `#` · 附件 · **复制**；Enter/闸门说明收成圆形 **i**，悬停看全文 |
 | 附件 | 自研 chip + 气泡 file-card | 先 `POST /sessions/:id/files`，再随消息 `attachments[]` |
 | Composer 面板 | 自研 slash / at / hash | `/` 指令；`@` 成员/节点；`#` → `#群聊`/`#文件夹`/`#1`…/`#出n` |
 | 未选会话 | 自研欢迎主视觉 | 居中：工具 Logo、一行口号（含终端守护者 / 熔炉连接一切）、一句说明、开聊按钮 |

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -521,20 +521,17 @@
                         class="file-input-hidden"
                         @change="onFileInputChange"
                       />
+                      <span class="composer-toolbar-spacer"></span>
                       <el-tooltip
                         :content="composerToolbarHint"
                         placement="top"
                         :show-after="200"
                       >
-                        <button
-                          type="button"
-                          class="composer-hint-i"
-                          aria-label="输入快捷说明"
-                        >
-                          <el-icon :size="16" class="composer-hint-i-icon">
-                            <InfoFilled />
-                          </el-icon>
-                        </button>
+                        <span
+                          class="gate-info-dot composer-hint-i"
+                          role="img"
+                          :aria-label="composerToolbarHint"
+                        >i</span>
                       </el-tooltip>
                       <div v-if="pendingGate" class="composer-gate-actions">
                         <template v-if="pendingGate.content?.mode === 'session_start'">
@@ -1110,7 +1107,6 @@
 import { ref, computed, watch, onUnmounted, nextTick, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { InfoFilled } from '@element-plus/icons-vue'
 import {
   formatBusinessIo,
   digestBusinessIo,
@@ -4657,27 +4653,14 @@ loadLists().then(() => {
   display: none;
 }
 
-.composer-hint-i {
+.composer-toolbar-spacer {
   flex: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  min-width: 22px;
-  height: 22px;
-  margin: 0;
-  padding: 0 4px;
-  border: 0;
-  background: transparent;
-  color: var(--ecw-text-3, #8b8f9a);
-  cursor: help;
+  min-width: 0;
 }
 
-.composer-hint-i-icon {
-  display: flex;
-}
-
-.composer-hint-i:hover {
-  color: var(--ecw-text-2, #6e6e73);
+.composer-hint-i {
+  flex-shrink: 0;
+  margin-right: 2px;
 }
 
 /* 附件区（参考 Plus-X 发送区附件卡片） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
不要星号。输入工具栏里原先那句「Enter=发消息 · 点「通过」启动」改成和闸门详情同一套**圆形 i**，贴在「通过」按钮左侧；悬停才弹出操作说明。

主分支上的 InfoFilled 实心信息标也拿掉，避免和星号一样不好认。

本地演示流已核对：工具栏没有 `*`，圆形 i 悬停可见「Enter=发消息 · 点「通过」启动」。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1163ca3a-ea9c-4dfd-b293-2dd90a9918a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1163ca3a-ea9c-4dfd-b293-2dd90a9918a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

