### PR TITLE
fix(ui): 输入说明圆形 i，审核态不并排两个

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,10 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-25 | M | Workbench.vue | 快捷说明改成圆形 i：热区只包图标，审核态不并排两个 i，悬停/点按/聚焦可看
+2026-08-25 | M | frontend-components.md | 记圆形 i 与审核态只留闸门详情 i
+2026-08-25 | M | CODE_CHANGE.md | 追加本轮条目
+
 2026-08-25 | M | packages/linux + win32 + darwin zip | 覆盖输入框星号提示
 2026-08-25 | M | Workbench.vue | 工具栏「Enter=发消息」灰字改成星号，悬停看说明
 2026-08-25 | M | frontend-components.md | 记输入框星号提示

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -6,7 +6,7 @@
 | 包名 | [`vue-element-plus-x`](https://www.npmjs.com/package/vue-element-plus-x) · [文档](https://v2.element-plus-x.com) |
 | 主题 | Element Plus / Plus-X **默认色板**；业务氛围用 `web/src/styles.css` 的 `--ecw-*` 变量 |
 | 代码入口 | `web/src/main.js`、`App.vue`、`styles.css`、`views/Workbench.vue` |
-| 更新日期 | 2026-07-20（0.4 封板：气泡 `noStyle` 单层） |
+| 更新日期 | 2026-08-25（输入说明圆形 i） |
 
 ---
 
@@ -46,7 +46,7 @@ app.use(ElementPlusX)
 | 中栏消息 | `BubbleList` | **`noStyle`** 去组件外壳；`#content` 内 `.bubble-rich` 单层气泡；`#header` 发送人、`#avatar` 首字 |
 | 终端消息 | `TerminalSessionCard` | 深灰玻璃终端卡；有限输出预览、运行态、进入终端与停止 |
 | 终端工作区 | `TerminalWorkspace` + `TerminalView` | 中栏占满；`xterm.js` 延迟加载，保留右侧流程轨；返回对话不停止进程 |
-| 中栏输入 | `XSender` | **`ref` 取文** + `@submit`；`@paste-file` 粘贴上传；`submit-type="enter"`；工具栏 `/` `@` `#` · 附件 · **复制**；Enter/闸门说明收成 **i** 图标，悬停看全文 |
+| 中栏输入 | `XSender` | **`ref` 取文** + `@submit`；`@paste-file` 粘贴上传；`submit-type="enter"`；工具栏 `/` `@` `#` · 附件 · **复制**；Enter/闸门说明收成圆形 **i**（贴闸门按钮左侧；同意/拒绝时只留闸门详情 i），悬停/点按看全文 |
 | 附件 | 自研 chip + 气泡 file-card | 先 `POST /sessions/:id/files`，再随消息 `attachments[]` |
 | Composer 面板 | 自研 slash / at / hash | `/` 指令；`@` 成员/节点；`#` → `#群聊`/`#文件夹`/`#1`…/`#出n` |
 | 未选会话 | 自研欢迎主视觉 | 居中：工具 Logo、一行口号（含终端守护者 / 熔炉连接一切）、一句说明、开聊按钮 |

--- a/web/src/views/Workbench.vue
+++ b/web/src/views/Workbench.vue
@@ -521,19 +521,20 @@
                         class="file-input-hidden"
                         @change="onFileInputChange"
                       />
+                      <div class="composer-toolbar-end">
                       <el-tooltip
+                        v-if="showComposerHintI"
                         :content="composerToolbarHint"
                         placement="top"
+                        :trigger="['hover', 'focus', 'click']"
                         :show-after="200"
                       >
                         <button
                           type="button"
-                          class="composer-hint-i"
-                          aria-label="输入快捷说明"
+                          class="gate-info-dot composer-hint-i"
+                          :aria-label="composerToolbarHint"
                         >
-                          <el-icon :size="16" class="composer-hint-i-icon">
-                            <InfoFilled />
-                          </el-icon>
+                          i
                         </button>
                       </el-tooltip>
                       <div v-if="pendingGate" class="composer-gate-actions">
@@ -598,6 +599,7 @@
                             拒绝
                           </el-button>
                         </template>
+                      </div>
                       </div>
                     </div>
                     <XSender
@@ -1110,7 +1112,6 @@
 import { ref, computed, watch, onUnmounted, nextTick, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { InfoFilled } from '@element-plus/icons-vue'
 import {
   formatBusinessIo,
   digestBusinessIo,
@@ -2060,6 +2061,15 @@ const composerToolbarHint = computed(() => {
     return 'Enter=附言 · 点同意/拒绝定局'
   }
   return '@ 成员/节点 · # 参数 · / 指令 · Enter 发送'
+})
+
+/** 同意/拒绝旁已有闸门详情 i，不再并排第二个 */
+const showComposerHintI = computed(() => {
+  if (!pendingGate.value) return true
+  const mode = pendingGate.value.content?.mode
+  return ['session_start', 'human_input', 'need_params', 'adapter_question', 'interrupted'].includes(
+    mode,
+  )
 })
 
 const composerFooterHint = computed(() => {
@@ -4377,11 +4387,18 @@ loadLists().then(() => {
   padding-top: 2px;
 }
 
+.composer-toolbar-end {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
 .composer-gate-actions {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-left: auto;
   flex-shrink: 0;
 }
 
@@ -4657,27 +4674,10 @@ loadLists().then(() => {
   display: none;
 }
 
-.composer-hint-i {
-  flex: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  min-width: 22px;
-  height: 22px;
+button.composer-hint-i {
   margin: 0;
-  padding: 0 4px;
   border: 0;
-  background: transparent;
-  color: var(--ecw-text-3, #8b8f9a);
-  cursor: help;
-}
-
-.composer-hint-i-icon {
-  display: flex;
-}
-
-.composer-hint-i:hover {
-  color: var(--ecw-text-2, #6e6e73);
+  font: inherit;
 }
 
 /* 附件区（参考 Plus-X 发送区附件卡片） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
按审查收口输入栏说明：

- 不再用 InfoFilled / 星号，改成和闸门详情同一套**圆形 i**
- 贴在「通过 / 提交」左侧，热区只包图标（不再 `flex: 1` 吞空白）
- **同意/拒绝**时只留闸门详情 i，避免并排两个 i
- 悬停、聚焦、点按都能看 Enter / 闸门说明

合进 main 后 GitHub Actions 会覆盖三平台运行包。

熔炉桌宠：main 上仍是两帧慢循环 GIF；chatgpt-pets 图集在草稿 #61，本次未合。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c32453a-3789-4e82-8d11-6e1819f4adf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c32453a-3789-4e82-8d11-6e1819f4adf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

