### PR TITLE
fix(release): 防止三平台生产包混入旧构建

### DIFF
--- a/.github/workflows/pack-release.yml
+++ b/.github/workflows/pack-release.yml
@@ -57,6 +57,7 @@ jobs:
           MAJOR="$(node -p "String(require('./package.json').version).split('.')[0]")"
           FILE="oh-my-co-work-v${MAJOR}-${PLAT}.zip"
           VER="$(node -p "JSON.parse(require('fs').readFileSync('server/config/about.json','utf8')).version")"
+          PUSHED=0
           # 多平台并行：rebase 后若 README/CURRENT 冲突，按目录内 zip 重写清单再继续
           for i in 1 2 3 4 5 6; do
             if ! git pull --rebase origin main; then
@@ -79,17 +80,21 @@ jobs:
               node scripts/pack-release.mjs --manifest-only
             fi
             git add packages/
-            if git diff --staged --quiet; then
-              echo "[pack] packages/ unchanged"
-              break
+            if ! git diff --staged --quiet; then
+              git commit -m "chore(packages): 更新 ${FILE} (${VER})" || true
+            else
+              echo "[pack] no new staged package changes"
             fi
-            if git commit -m "chore(packages): 更新 ${FILE} (${VER})"; then
-              if git push origin HEAD:main; then
-                break
-              fi
+            if git push origin HEAD:main; then
+              PUSHED=1
+              break
             fi
             sleep $((i * 4))
           done
+          if [ "$PUSHED" -ne 1 ]; then
+            echo "[pack] failed to push ${FILE} after retries" >&2
+            exit 1
+          fi
 
   release:
     needs: pack
@@ -108,12 +113,17 @@ jobs:
             git pull origin main
             COUNT=$(ls -1 packages/oh-my-co-work-v*.zip 2>/dev/null | wc -l | tr -d ' ')
             echo "[release] zip count=$COUNT"
-            if [ "$COUNT" -ge 1 ]; then
+            if [ "$COUNT" -ge 3 ]; then
               break
             fi
             sleep 15
           done
           ls -la packages/*.zip
+
+      - name: Validate three platform packages
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.sha }}
+        run: node scripts/validate-release-packages.mjs --expected-sha "$EXPECTED_SOURCE_SHA"
 
       - name: Publish GitHub Release
         env:

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,12 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-26 | M | .github/workflows/pack-release.yml | 三平台包推送失败即终止，latest 发布前强制校验同源与新熔炉图集
+2026-08-26 | M | scripts/pack-release.mjs / package.json | 运行包写 BUILD_INFO 与旁证元数据，并提供生产包校验命令
+2026-08-26 | A | scripts/validate-release-packages.mjs | 校验三平台版本、源码提交、旁证及桌宠资源一致性
+2026-08-26 | A | server/test/releasePackages.test.js | 覆盖新图集、旧资源拒绝和三平台同源规则
+2026-08-26 | M | README.md / packages/README.md / docs/RELEASE-USER.md | 同步生产包一致性门禁与 BUILD_INFO 排障说明
+2026-08-26 | M | CODE_CHANGE.md | 追加生产包一致性修复条目
 2026-08-26 | M | FurnaceAvatar.vue | 头像 title 附带 chatgpt-pets 版权短声明
 2026-08-26 | M | FurnaceSprite.vue / FurnaceWorkspace.vue | 桌宠立绘旁展示 chatgpt-pets MIT 版权短声明
 2026-08-26 | M | About.vue / about.json | 关于页写明立绘从 chatgpt-pets git 复制

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,7 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-26 | M | appSettings.js / furnace.test.js / furnaceLifecycle.test.js | 测试使用隔离设置文件，避免测试污染仓库配置
 2026-08-26 | M | .github/workflows/pack-release.yml | 三平台包推送失败即终止，latest 发布前强制校验同源与新熔炉图集
 2026-08-26 | M | scripts/pack-release.mjs / package.json | 运行包写 BUILD_INFO 与旁证元数据，并提供生产包校验命令
 2026-08-26 | A | scripts/validate-release-packages.mjs | 校验三平台版本、源码提交、旁证及桌宠资源一致性

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ macOS    → 解压后运行 ./start.sh
 Linux    → 解压后运行 ./start.sh
 ```
 
-运行包已包含依赖，通常不需要再次执行 `npm install`；本机仍需 Node.js 18+。桌宠图集打在前端里：要看 **chatgpt-pets 李慕婉**，请重新下载 zip 解压覆盖，不要沿用旧文件夹。
+运行包已包含依赖，通常不需要再次执行 `npm install`；本机仍需 Node.js 18+。桌宠图集打在前端里：要看 **chatgpt-pets 李慕婉**，请重新下载 zip 解压覆盖，不要沿用旧文件夹。latest 发布前会强制校验 Windows / macOS / Linux 三包来自同一源码提交且都含当前图集；包内 `BUILD_INFO.json` 可用于排障。
 
 ### 从源码启动
 

--- a/docs/RELEASE-USER.md
+++ b/docs/RELEASE-USER.md
@@ -11,6 +11,7 @@
 | **同大版本 + 同平台** | **覆盖替换** 对应 zip（小版本只留最新） |
 | **新大版本** | 只保留当前大版本包，**旧大版本 zip 全部删除** |
 | **多平台** | 当前大版本内 linux / win32 / darwin 各一份 |
+| **一致性门禁** | latest 发布前会检查三平台包内 `BUILD_INFO.json`：版本和源码提交必须一致，且必须含当前熔炉图集；任一平台旧包或缺包都会阻止发布 |
 
 按本机系统选：
 
@@ -72,7 +73,7 @@ ACW_HEADLESS_BROWSER=1 node start.mjs
 
 运行后会在解压目录生成 `data/`（SQLite、日志、群报告等）。
 
-当前运行包版本以 [`packages/CURRENT.txt`](../packages/CURRENT.txt) 为准（大版本 v3，小版本随同平台 zip 覆盖）。
+当前运行包版本以 [`packages/CURRENT.txt`](../packages/CURRENT.txt) 为准（大版本 v3，小版本随同平台 zip 覆盖）。排障时同时看 `commit.<平台>`；正常发布后三个平台提交应一致。每个 zip 根目录还有 `BUILD_INFO.json`，可确认该包实际使用的源码提交和构建时间。
 
 ## 注意
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start:server": "npm run start -w server",
     "backup": "node scripts/backup.mjs",
     "pack": "node scripts/pack-release.mjs",
+    "validate:packages": "node scripts/validate-release-packages.mjs",
     "build": "npm run build -w web",
     "test": "npm run test -w server"
   },

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,14 +8,15 @@
 - **同大版本**：覆盖替换同平台 zip（小版本只留最新）
 - **新大版本**：只保留当前大版本包，旧大版本 zip 全部删除
 - **多平台**：linux / win32 / darwin 各一份（当前大版本内互不覆盖）
+- **发布门禁**：三平台包内 `BUILD_INFO.json` 的版本、源码提交必须一致，并包含当前熔炉图集；任一不符则不发布 latest
 
 ## 仓库内文件
 
-| 平台 | 文件 | 大小 |
-|------|------|------|
-| darwin-arm64 | [`oh-my-co-work-v3-darwin-arm64.zip`](./oh-my-co-work-v3-darwin-arm64.zip) | 22125521 |
-| linux-x64 | [`oh-my-co-work-v3-linux-x64.zip`](./oh-my-co-work-v3-linux-x64.zip) | 24041139 |
-| win32-x64 | [`oh-my-co-work-v3-win32-x64.zip`](./oh-my-co-work-v3-win32-x64.zip) | 22120374 |
+| 平台 | 文件 | 大小 | 源码提交 | 构建时间 |
+|------|------|------|----------|----------|
+| darwin-arm64 | [`oh-my-co-work-v3-darwin-arm64.zip`](./oh-my-co-work-v3-darwin-arm64.zip) | 22125521 | `8a83a64` | 2026-08-21T02:05:17.000Z |
+| linux-x64 | [`oh-my-co-work-v3-linux-x64.zip`](./oh-my-co-work-v3-linux-x64.zip) | 24041139 | `5f44493` | 2026-08-26T07:03:21.634Z |
+| win32-x64 | [`oh-my-co-work-v3-win32-x64.zip`](./oh-my-co-work-v3-win32-x64.zip) | 22120374 | `8a83a64` | 2026-08-21T02:05:17.000Z |
 
 版本：`3.7.0`（大版本 v3）
 

--- a/scripts/pack-release.mjs
+++ b/scripts/pack-release.mjs
@@ -39,9 +39,9 @@ function sh(cmd, args, opts = {}) {
   if (r.status !== 0) throw new Error(`${cmd} ${args.join(' ')} failed: ${r.status}`)
 }
 
-function gitShort() {
+function gitCommit() {
   try {
-    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { cwd: ROOT })
+    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT })
       .toString()
       .trim()
   } catch {
@@ -400,7 +400,7 @@ function majorFromZipName(name) {
 function pruneOlderMajorZips(keepMajor) {
   if (!fs.existsSync(PACKAGES_DIR)) return
   for (const name of fs.readdirSync(PACKAGES_DIR)) {
-    if (!name.endsWith('.zip')) continue
+    if (!name.endsWith('.zip') && !name.endsWith('.build.json')) continue
     const m = majorFromZipName(name)
     if (m == null || m === keepMajor) continue
     const full = path.join(PACKAGES_DIR, name)
@@ -409,7 +409,21 @@ function pruneOlderMajorZips(keepMajor) {
   }
 }
 
-function writePackagesManifest({ ver, major, sha, plat, gitZipName, size }) {
+function buildMetaPathForZip(zipName) {
+  return path.join(PACKAGES_DIR, `${zipName.slice(0, -4)}.build.json`)
+}
+
+function readBuildMetaForZip(zipName) {
+  const p = buildMetaPathForZip(zipName)
+  if (!fs.existsSync(p)) return null
+  try {
+    return readJson(p)
+  } catch {
+    return null
+  }
+}
+
+function writePackagesManifest({ ver, major, sha, builtAt, plat, gitZipName, size }) {
   const curPath = path.join(PACKAGES_DIR, 'CURRENT.txt')
   const prev = fs.existsSync(curPath)
     ? parseCurrentTxt(fs.readFileSync(curPath, 'utf8'))
@@ -426,24 +440,26 @@ function writePackagesManifest({ ver, major, sha, plat, gitZipName, size }) {
     const p = platformFromZipName(f)
     if (!p) continue
     const full = path.join(PACKAGES_DIR, f)
+    const meta = readBuildMetaForZip(f)
     byPlat[p] = {
       file: f,
       size: fs.statSync(full).size,
-      commit: prev[`commit.${p}`] || prev.commit || '',
-      built: prev[`built.${p}`] || '',
+      commit: meta?.sourceCommit || prev[`commit.${p}`] || prev.commit || '',
+      built: meta?.builtAt || prev[`built.${p}`] || '',
     }
   }
   byPlat[plat] = {
     file: gitZipName,
     size,
     commit: sha,
-    built: new Date().toISOString(),
+    built: builtAt,
   }
 
   const platOrder = Object.keys(byPlat).sort()
   const tableRows = platOrder.map((p) => {
     const b = byPlat[p]
-    return `| ${p} | [\`${b.file}\`](./${b.file}) | ${b.size} |`
+    const commit = b.commit ? `\`${String(b.commit).slice(0, 12)}\`` : '—'
+    return `| ${p} | [\`${b.file}\`](./${b.file}) | ${b.size} | ${commit} | ${b.built || '—'} |`
   })
 
   const lines = [
@@ -457,11 +473,12 @@ function writePackagesManifest({ ver, major, sha, plat, gitZipName, size }) {
     '- **同大版本**：覆盖替换同平台 zip（小版本只留最新）',
     '- **新大版本**：只保留当前大版本包，旧大版本 zip 全部删除',
     '- **多平台**：linux / win32 / darwin 各一份（当前大版本内互不覆盖）',
+    '- **发布门禁**：三平台包内 `BUILD_INFO.json` 的版本、源码提交必须一致，并包含当前熔炉图集；任一不符则不发布 latest',
     '',
     '## 仓库内文件',
     '',
-    '| 平台 | 文件 | 大小 |',
-    '|------|------|------|',
+    '| 平台 | 文件 | 大小 | 源码提交 | 构建时间 |',
+    '|------|------|------|----------|----------|',
     ...tableRows,
     '',
     `版本：\`${ver}\`（大版本 v${major}）`,
@@ -529,7 +546,8 @@ async function mainAsync() {
     /* ignore */
   }
   const major = majorOf(ver)
-  const sha = gitShort()
+  const sha = gitCommit()
+  const builtAt = new Date().toISOString()
   const plat = platformTag()
   const folderName = `oh-my-co-work-v${major}-${plat}`
   const stage = path.join(OUT_ROOT, folderName)
@@ -627,10 +645,27 @@ async function mainAsync() {
       `major=${major}`,
       `platform=${plat}`,
       `commit=${sha}`,
-      `built=${new Date().toISOString()}`,
+      `built=${builtAt}`,
       `needsNpmInstall=false`,
       `autoExit=default-off`,
     ].join('\n') + '\n',
+    'utf8',
+  )
+  const buildInfo = {
+    schemaVersion: 1,
+    name: 'oh-my-co-work',
+    kind: 'runtime-bundle',
+    version: ver,
+    major,
+    platform: plat,
+    sourceCommit: sha,
+    builtAt,
+    needsNpmInstall: false,
+    requiredAssets: ['web/dist/assets/spritesheet-*.webp'],
+  }
+  fs.writeFileSync(
+    path.join(stage, 'BUILD_INFO.json'),
+    JSON.stringify(buildInfo, null, 2) + '\n',
     'utf8',
   )
 
@@ -672,11 +707,16 @@ async function mainAsync() {
     console.log('[pack] removed legacy', legacy)
   }
   fs.copyFileSync(zipPath, gitZipPath)
+  fs.writeFileSync(
+    buildMetaPathForZip(gitZipName),
+    JSON.stringify(buildInfo, null, 2) + '\n',
+    'utf8',
+  )
   // 一个大版本只留当前最新：删掉其它大版本的全部运行包
   pruneOlderMajorZips(major)
 
   const size = fs.statSync(gitZipPath).size
-  writePackagesManifest({ ver, major, sha, plat, gitZipName, size })
+  writePackagesManifest({ ver, major, sha, builtAt, plat, gitZipName, size })
 
   console.log('[pack] ok', gitZipPath, `(${size} bytes)`)
   console.log('[pack] user: unzip → start.bat / ./start.sh （无需 npm install）')
@@ -711,7 +751,6 @@ function regenerateManifestOnly() {
     }
   }
   const major = majorOf(ver)
-  const sha = gitShort()
   const plat = platformTag()
   pruneOlderMajorZips(major)
   const files = fs.existsSync(PACKAGES_DIR)
@@ -725,10 +764,12 @@ function regenerateManifestOnly() {
   const mine =
     files.find((f) => f.includes(`-${plat}.`)) || files[files.length - 1]
   const size = fs.statSync(path.join(PACKAGES_DIR, mine)).size
+  const meta = readBuildMetaForZip(mine)
   writePackagesManifest({
     ver,
     major,
-    sha,
+    sha: meta?.sourceCommit || '',
+    builtAt: meta?.builtAt || '',
     plat: platformFromZipName(mine) || plat,
     gitZipName: mine,
     size,

--- a/scripts/validate-release-packages.mjs
+++ b/scripts/validate-release-packages.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const PACKAGES_DIR = path.join(ROOT, 'packages')
+const REQUIRED_PLATFORMS = ['darwin-arm64', 'linux-x64', 'win32-x64']
+
+function normalizeEntry(entry) {
+  return String(entry || '').replaceAll('\\', '/').replace(/^\.\/+/, '')
+}
+
+export function validateArchiveEntries(entries, platform) {
+  const normalized = entries.map(normalizeEntry)
+  const buildInfoEntries = normalized.filter(
+    (entry) => entry === 'BUILD_INFO.json' || entry.endsWith('/BUILD_INFO.json'),
+  )
+  if (buildInfoEntries.length !== 1) {
+    throw new Error(`${platform}: BUILD_INFO.json 数量应为 1，实际 ${buildInfoEntries.length}`)
+  }
+  if (!normalized.some((entry) => /\/web\/dist\/assets\/spritesheet-[^/]+\.webp$/.test(`/${entry}`))) {
+    throw new Error(`${platform}: 缺少 web/dist/assets/spritesheet-*.webp`)
+  }
+  if (normalized.some((entry) => /\/web\/dist\/assets\/furnace-idle-[^/]+\.(gif|png)$/i.test(`/${entry}`))) {
+    throw new Error(`${platform}: 仍包含旧版 furnace-idle GIF/PNG`)
+  }
+  return buildInfoEntries[0]
+}
+
+export function validateBuildMetadataSet({
+  metadata,
+  expectedCommit,
+  expectedVersion,
+  requiredPlatforms = REQUIRED_PLATFORMS,
+}) {
+  const byPlatform = new Map(metadata.map((item) => [item.platform, item]))
+  for (const platform of requiredPlatforms) {
+    const item = byPlatform.get(platform)
+    if (!item) throw new Error(`缺少 ${platform} 构建信息`)
+    if (item.kind !== 'runtime-bundle') {
+      throw new Error(`${platform}: kind=${item.kind || '空'}，应为 runtime-bundle`)
+    }
+    if (expectedVersion && item.version !== expectedVersion) {
+      throw new Error(`${platform}: version=${item.version}，应为 ${expectedVersion}`)
+    }
+    if (expectedCommit && item.sourceCommit !== expectedCommit) {
+      throw new Error(
+        `${platform}: sourceCommit=${item.sourceCommit || '空'}，应为 ${expectedCommit}`,
+      )
+    }
+  }
+  const commits = new Set(
+    requiredPlatforms.map((platform) => byPlatform.get(platform)?.sourceCommit).filter(Boolean),
+  )
+  if (commits.size !== 1) {
+    throw new Error(`三平台源码提交不一致：${[...commits].join(', ') || '均为空'}`)
+  }
+  return true
+}
+
+function unzipList(zipPath) {
+  return execFileSync('unzip', ['-Z1', zipPath], { encoding: 'utf8' })
+    .split(/\r?\n/)
+    .filter(Boolean)
+}
+
+function unzipText(zipPath, entry) {
+  return execFileSync('unzip', ['-p', zipPath, entry], { encoding: 'utf8' })
+}
+
+function argValue(name) {
+  const i = process.argv.indexOf(name)
+  return i >= 0 ? process.argv[i + 1] : ''
+}
+
+export function validateReleasePackages({
+  packagesDir = PACKAGES_DIR,
+  expectedCommit = '',
+} = {}) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'))
+  const version = pkg.version
+  const major = String(version).split('.')[0]
+  const metadata = []
+
+  for (const platform of REQUIRED_PLATFORMS) {
+    const zipName = `oh-my-co-work-v${major}-${platform}.zip`
+    const zipPath = path.join(packagesDir, zipName)
+    if (!fs.existsSync(zipPath)) throw new Error(`缺少生产包 ${zipName}`)
+    const entries = unzipList(zipPath)
+    const infoEntry = validateArchiveEntries(entries, platform)
+    const info = JSON.parse(unzipText(zipPath, infoEntry))
+    if (info.platform !== platform) {
+      throw new Error(`${zipName}: BUILD_INFO platform=${info.platform || '空'}`)
+    }
+    const sidecarPath = path.join(
+      packagesDir,
+      `oh-my-co-work-v${major}-${platform}.build.json`,
+    )
+    if (!fs.existsSync(sidecarPath)) throw new Error(`缺少构建旁证 ${path.basename(sidecarPath)}`)
+    const sidecar = JSON.parse(fs.readFileSync(sidecarPath, 'utf8'))
+    if (JSON.stringify(sidecar) !== JSON.stringify(info)) {
+      throw new Error(`${platform}: zip 内 BUILD_INFO 与 .build.json 不一致`)
+    }
+    metadata.push(info)
+  }
+
+  validateBuildMetadataSet({
+    metadata,
+    expectedCommit,
+    expectedVersion: version,
+  })
+  console.log(
+    `[release-check] ok version=${version} commit=${metadata[0].sourceCommit} platforms=${REQUIRED_PLATFORMS.join(',')}`,
+  )
+  return metadata
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  try {
+    validateReleasePackages({
+      expectedCommit: argValue('--expected-sha') || process.env.EXPECTED_SOURCE_SHA || '',
+    })
+  } catch (error) {
+    console.error('[release-check] FAIL', error?.message || error)
+    process.exitCode = 1
+  }
+}

--- a/server/src/appSettings.js
+++ b/server/src/appSettings.js
@@ -4,7 +4,9 @@ import { ROOT, getDb, parseJson } from './db.js'
 import { killSessionProcesses } from './processRegistry.js'
 import { defaultStepFlow, normalizeFurnaceSurface } from '@acw/shared'
 
-const SETTINGS_PATH = path.join(ROOT, 'server/config/app-settings.json')
+const SETTINGS_PATH = process.env.ACW_APP_SETTINGS_PATH
+  ? path.resolve(process.env.ACW_APP_SETTINGS_PATH)
+  : path.join(ROOT, 'server/config/app-settings.json')
 
 const DEMO_MEMBER_NAMES = new Set(['echo', 'script_cmd'])
 const DEMO_GROUP_TITLES = new Set(['演示流'])

--- a/server/test/furnace.test.js
+++ b/server/test/furnace.test.js
@@ -6,6 +6,7 @@ import test from 'node:test'
 
 const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'acw-furnace-'))
 process.env.ACW_DATA_ROOT = dataRoot
+process.env.ACW_APP_SETTINGS_PATH = path.join(dataRoot, 'app-settings.json')
 
 const { initDb } = await import('../src/db.js')
 initDb()

--- a/server/test/furnaceLifecycle.test.js
+++ b/server/test/furnaceLifecycle.test.js
@@ -6,6 +6,7 @@ import test from 'node:test'
 
 const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'acw-furnace-life-'))
 process.env.ACW_DATA_ROOT = dataRoot
+process.env.ACW_APP_SETTINGS_PATH = path.join(dataRoot, 'app-settings.json')
 
 const { initDb } = await import('../src/db.js')
 initDb()

--- a/server/test/releasePackages.test.js
+++ b/server/test/releasePackages.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  validateArchiveEntries,
+  validateBuildMetadataSet,
+} from '../../scripts/validate-release-packages.mjs'
+
+test('release archive requires BUILD_INFO and the new furnace spritesheet', () => {
+  const entry = validateArchiveEntries(
+    [
+      'oh-my-co-work-v3-linux-x64/BUILD_INFO.json',
+      'oh-my-co-work-v3-linux-x64/web/dist/assets/spritesheet-abc.webp',
+    ],
+    'linux-x64',
+  )
+  assert.equal(entry, 'oh-my-co-work-v3-linux-x64/BUILD_INFO.json')
+})
+
+test('release archive rejects the retired furnace idle assets', () => {
+  assert.throws(
+    () =>
+      validateArchiveEntries(
+        [
+          'BUILD_INFO.json',
+          'web/dist/assets/spritesheet-abc.webp',
+          'web/dist/assets/furnace-idle-old.gif',
+        ],
+        'win32-x64',
+      ),
+    /旧版 furnace-idle/,
+  )
+})
+
+test('all platform packages must share the expected source commit and version', () => {
+  const sourceCommit = 'a'.repeat(40)
+  const metadata = ['darwin-arm64', 'linux-x64', 'win32-x64'].map((platform) => ({
+    kind: 'runtime-bundle',
+    version: '3.7.0',
+    platform,
+    sourceCommit,
+  }))
+  assert.equal(
+    validateBuildMetadataSet({
+      metadata,
+      expectedCommit: sourceCommit,
+      expectedVersion: '3.7.0',
+    }),
+    true,
+  )
+
+  metadata[2] = { ...metadata[2], sourceCommit: 'b'.repeat(40) }
+  assert.throws(
+    () =>
+      validateBuildMetadataSet({
+        metadata,
+        expectedCommit: sourceCommit,
+        expectedVersion: '3.7.0',
+      }),
+    /sourceCommit/,
+  )
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
Windows / macOS 的 3.7.0 包仍包含旧 `furnace-idle.gif/png`，Linux 包已包含李慕婉 `spritesheet.webp`。现有 Release 只检查至少一个 zip 存在，也不校验三包是否来自同一源码提交。

## 改动
- 每个运行包根目录写入 `BUILD_INFO.json`，记录完整源码 SHA、版本、平台和构建时间。
- `packages/` 同步生成平台 `.build.json` 旁证；README 显示源码提交和构建时间。
- latest 发布前强制检查 Windows / macOS / Linux 三包：
  - 三包齐全；
  - 版本和源码 SHA 完全一致且等于触发构建的提交；
  - zip 内 BUILD_INFO 与旁证一致；
  - 包含 `spritesheet-*.webp`；
  - 不再包含旧 `furnace-idle.gif/png`。
- 任一平台包推送重试耗尽时令 Pack job 失败，不再静默进入 Release。
- 新增纯逻辑测试，并隔离熔炉测试的应用设置文件，避免测试污染仓库配置。

## 文档
- 同步 README、`packages/README.md`、`docs/RELEASE-USER.md` 与 `CODE_CHANGE.md`。

## 验证
- `npm run test`：93/93 通过。
- `npm run build`：通过，产出 `spritesheet-BBlR4l8X.webp`。
- Linux 实际 `npm run pack` 冒烟通过：zip 内含 BUILD_INFO 和新 spritesheet，未含旧 furnace-idle 资源。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0066f6aa-78b9-4056-8451-13dd02484f96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0066f6aa-78b9-4056-8451-13dd02484f96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

