### PR TITLE
修复熔炉 GUI/TUI 看不到连贯历史，GUI 改为对话框布局

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,12 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-31 | M | web/src/components/terminal/TerminalView.vue | 撤回熔炉吞备用屏 / 强制 overflow-y:scroll：这两项会让 Grok 鼠标协议和可点按钮失效
+2026-08-31 | M | web/src/components/terminal/FurnaceWorkspace.vue | TUI 恢复铺满原生终端；对话记录改为可选右侧栏（默认关），不再垫在终端上方挤占高度
+2026-08-31 | M | docs/crucible-gui-plain.md | TUI 口径改回完整 Grok（可点按钮）；历史上翻在 GUI
+2026-08-31 | M | docs/frontend-components.md | 干活面 TUI 说明改为完整 Grok 可点按钮
+2026-08-31 | M | CODE_CHANGE.md | 追加熔炉 TUI 鼠标/按钮修复条目
+
 2026-08-31 | M | shared/ptyPlain.js | 熔炉 GUI 累积清屏/备用屏前的可读正文，不再只导出当前一屏；新增 takeFurnaceAssistantDelta / buildFurnaceChatTurns
 2026-08-31 | M | shared/index.js | 导出熔炉对话轮次辅助函数
 2026-08-31 | M | server/test/ptyPlain.test.js | 覆盖跨屏历史、去重、用户原文切轮

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,11 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-31 | M | web/src/components/terminal/TerminalView.vue | 按产品取舍：TUI 继续吞备用屏以保住上翻历史；Grok 画面内可点按钮不做了
+2026-08-31 | M | web/src/components/terminal/FurnaceWorkspace.vue | 撤回「记录」侧栏方案，TUI 仍是上方对话记录 + 下方终端
+2026-08-31 | M | docs/crucible-gui-plain.md | 写明 TUI 可点按钮可能不准，以键盘为准
+2026-08-31 | M | CODE_CHANGE.md | 追加「点不了就算了、把历史上翻加回 TUI」条目
+
 2026-08-31 | M | web/src/components/terminal/TerminalView.vue | 撤回熔炉吞备用屏 / 强制 overflow-y:scroll：这两项会让 Grok 鼠标协议和可点按钮失效
 2026-08-31 | M | web/src/components/terminal/FurnaceWorkspace.vue | TUI 恢复铺满原生终端；对话记录改为可选右侧栏（默认关），不再垫在终端上方挤占高度
 2026-08-31 | M | docs/crucible-gui-plain.md | TUI 口径改回完整 Grok（可点按钮）；历史上翻在 GUI

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,15 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-08-31 | M | shared/ptyPlain.js | 熔炉 GUI 累积清屏/备用屏前的可读正文，不再只导出当前一屏；新增 takeFurnaceAssistantDelta / buildFurnaceChatTurns
+2026-08-31 | M | shared/index.js | 导出熔炉对话轮次辅助函数
+2026-08-31 | M | server/test/ptyPlain.test.js | 覆盖跨屏历史、去重、用户原文切轮
+2026-08-31 | M | web/src/components/terminal/FurnaceWorkspace.vue | GUI 改成左右对话框气泡，消息区常显滚动条，本地记下用户轮次
+2026-08-31 | M | web/src/components/terminal/TerminalView.vue | 熔炉 preserveHistory：吞备用屏、清屏前把当前画面推进 scrollback，滚动条加粗常显
+2026-08-31 | M | docs/crucible-gui-plain.md | 口径改为可上翻的对话框历史
+2026-08-31 | M | docs/frontend-components.md | 干活面说明改为 GUI 气泡 / TUI 可上翻
+2026-08-31 | M | CODE_CHANGE.md | 追加熔炉历史与对话框布局条目
+
 2026-08-27 | M | README.md | 补截图说明、源码一键启动（node start.mjs / start.bat / start.sh）、场外协助折叠标成员、支持与交流邮箱
 2026-08-27 | M | CODE_CHANGE.md | 追加 README 正文修订条目
 

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -25,8 +25,8 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 2026-08-31 | M | shared/ptyPlain.js | 熔炉 GUI 累积清屏/备用屏前的可读正文，不再只导出当前一屏；新增 takeFurnaceAssistantDelta / buildFurnaceChatTurns
 2026-08-31 | M | shared/index.js | 导出熔炉对话轮次辅助函数
 2026-08-31 | M | server/test/ptyPlain.test.js | 覆盖跨屏历史、去重、用户原文切轮
-2026-08-31 | M | web/src/components/terminal/FurnaceWorkspace.vue | GUI 改成左右对话框气泡，消息区常显滚动条，本地记下用户轮次
-2026-08-31 | M | web/src/components/terminal/TerminalView.vue | 熔炉 preserveHistory：吞备用屏、清屏前把当前画面推进 scrollback，滚动条加粗常显
+2026-08-31 | M | web/src/components/terminal/FurnaceWorkspace.vue | GUI 改成左右对话框气泡，消息贴底可上翻；TUI 上方加同一份可滚动对话记录；去掉用户回声与重复段
+2026-08-31 | M | web/src/components/terminal/TerminalView.vue | 熔炉 preserveHistory：吞备用屏让主缓冲能滚；滚动条加粗常显（不在 CSI 回调里 write，避免回放冲掉画面）
 2026-08-31 | M | docs/crucible-gui-plain.md | 口径改为可上翻的对话框历史
 2026-08-31 | M | docs/frontend-components.md | 干活面说明改为 GUI 气泡 / TUI 可上翻
 2026-08-31 | M | CODE_CHANGE.md | 追加熔炉历史与对话框布局条目

--- a/docs/crucible-gui-plain.md
+++ b/docs/crucible-gui-plain.md
@@ -34,14 +34,15 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 
 ## 2. 已决口径
 
-**GUI = 可读正文 + 底部输入。**  
-菜单、快捷键、模型条、登录态 **只在 TUI**。
+**GUI = 对话框（可上翻的历史气泡）+ 底部输入。**  
+菜单、快捷键、模型条、登录态 **只在 TUI**。TUI 同样保留滚动历史（吞备用屏，清屏前把当前画面推进 scrollback）。
 
 | 层 | 做什么 |
 |----|--------|
 | 1. 屏幕 | 继续 `renderPtyPlainText`（光标、擦行、中文宽度） |
 | 2. 去壳 | 去掉框线字符、纯装饰行、Grok 底栏/状态条惯用句 |
-| 3. 排版 | 正文用普通换行；**不再按终端列宽画表格** |
+| 3. 历史 | 清屏 / 进备用屏之前把可读帧并进累积正文，不再只留当前一屏 |
+| 4. 排版 | 用户右气泡、Grok 左气泡；普通换行，不按终端列宽画表格 |
 
 不做：
 
@@ -73,17 +74,16 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 
 ## 4. 排版
 
-- `<pre>`：**不要** `word-break: break-word` 去拆 120 列框（框已经去掉）。
-- 使用 `pre-wrap` 只为长句在气泡里换行，按词/按中文即可。
-- 标签改为「Grok · 可读正文」；空态为欢迎卡（能干什么），不把长 prompt 贴进对话。
+- 对话气泡：用户右对齐蓝泡，Grok 左对齐白泡；空态仍为欢迎卡。
+- 消息区 `overflow-y: scroll` 且滚动条常显，避免历史被裁成一屏却看不出能滚。
 
 ---
 
 ## 5. 验收
 
-- 发「你好」之后，GUI 里能读到回答，**不应**再出现底栏 `Enter:send` 整行。
-- **不应**再出现断开的 ASCII 盒子把字切开。
-- 切 TUI，原 Grok 菜单和快捷键仍在。
+- 发两轮「你好」之后，GUI **两轮都在**，能上翻，不是只剩当前屏一块 `<pre>`。
+- **不应**再出现底栏 `Enter:send` 整行、断开的 ASCII 盒子。
+- 切 TUI，原 Grok 菜单和快捷键仍在；右侧滚动条可上翻更早画面。
 - 附件路径仍是一行写入同一进程。
 
 ---
@@ -92,6 +92,7 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 
 | 文件 | 职责 |
 |------|------|
-| `shared/ptyPlain.js` | `renderPtyPlainText` + `furnaceGuiTranscript`（去壳） |
-| `FurnaceWorkspace.vue` | GUI 用 transcript；样式按 §4 |
-| `server/test/ptyPlain.test.js` | 去壳用例 |
+| `shared/ptyPlain.js` | `furnaceGuiTranscript` 累积清屏前可读帧；`takeFurnaceAssistantDelta` / `buildFurnaceChatTurns` |
+| `FurnaceWorkspace.vue` | GUI 对话框气泡 + 常显滚动条 |
+| `TerminalView.vue` | 熔炉 `preserveHistory`：备用屏不进 alt buffer，清屏前推入 scrollback |
+| `server/test/ptyPlain.test.js` | 去壳、跨屏历史、对话轮次 |

--- a/docs/crucible-gui-plain.md
+++ b/docs/crucible-gui-plain.md
@@ -35,7 +35,7 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 ## 2. 已决口径
 
 **GUI = 对话框（可上翻的历史气泡）+ 底部输入。**  
-菜单、快捷键、模型条、登录态 **只在 TUI**。TUI 同样保留滚动历史（吞备用屏，清屏前把当前画面推进 scrollback）。
+菜单、快捷键、模型条、登录态、**可点的 TUI 按钮** **只在 TUI**。TUI 必须是完整 Grok 终端（备用屏 + 鼠标协议），不要吞 CSI、不要把历史垫在终端上面挤占高度。对话历史上翻在 **GUI**；TUI 顶栏「记录」是可选侧栏，默认关。
 
 | 层 | 做什么 |
 |----|--------|
@@ -83,7 +83,8 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 
 - 发两轮「你好」之后，GUI **两轮都在**，能上翻，不是只剩当前屏一块 `<pre>`。
 - **不应**再出现底栏 `Enter:send` 整行、断开的 ASCII 盒子。
-- 切 TUI，原 Grok 菜单和快捷键仍在；右侧滚动条可上翻更早画面。
+- 切 TUI，原 Grok 菜单、快捷键和可点按钮仍在（铺满终端，不被历史层挡住）。
+- 对话历史上翻在 GUI；TUI 可用「记录」侧栏，默认关。
 - 附件路径仍是一行写入同一进程。
 
 ---
@@ -93,6 +94,6 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 | 文件 | 职责 |
 |------|------|
 | `shared/ptyPlain.js` | `furnaceGuiTranscript` 累积清屏前可读帧；`takeFurnaceAssistantDelta` / `buildFurnaceChatTurns` |
-| `FurnaceWorkspace.vue` | GUI 对话框气泡 + 常显滚动条 |
-| `TerminalView.vue` | 熔炉 `preserveHistory`：备用屏不进 alt buffer，清屏前推入 scrollback |
+| `FurnaceWorkspace.vue` | GUI 对话框气泡；TUI 铺满原生终端，可选「记录」侧栏 |
+| `TerminalView.vue` | 原样 xterm（不吞备用屏，不强制 overflow 抢鼠标） |
 | `server/test/ptyPlain.test.js` | 去壳、跨屏历史、对话轮次 |

--- a/docs/crucible-gui-plain.md
+++ b/docs/crucible-gui-plain.md
@@ -35,7 +35,7 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 ## 2. 已决口径
 
 **GUI = 对话框（可上翻的历史气泡）+ 底部输入。**  
-菜单、快捷键、模型条、登录态、**可点的 TUI 按钮** **只在 TUI**。TUI 必须是完整 Grok 终端（备用屏 + 鼠标协议），不要吞 CSI、不要把历史垫在终端上面挤占高度。对话历史上翻在 **GUI**；TUI 顶栏「记录」是可选侧栏，默认关。
+菜单、快捷键、模型条、登录态 **只在 TUI**。TUI 上方保留同一份可滚动对话记录（终端仍铺在下面）。为了能上翻，会吞备用屏；Grok 画面里那些可点按钮可能点不准，**以键盘快捷键为准**，不必再为点击去拆历史。
 
 | 层 | 做什么 |
 |----|--------|
@@ -83,8 +83,7 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 
 - 发两轮「你好」之后，GUI **两轮都在**，能上翻，不是只剩当前屏一块 `<pre>`。
 - **不应**再出现底栏 `Enter:send` 整行、断开的 ASCII 盒子。
-- 切 TUI，原 Grok 菜单、快捷键和可点按钮仍在（铺满终端，不被历史层挡住）。
-- 对话历史上翻在 GUI；TUI 可用「记录」侧栏，默认关。
+- 切 TUI：上方可上翻对话记录，下方是活终端。画面里的可点按钮可能点不准，用键盘（Shift+Tab / Ctrl+x 等）。
 - 附件路径仍是一行写入同一进程。
 
 ---
@@ -94,6 +93,6 @@ TUI 皮（xterm）已经能画对。GUI 若继续「整屏抄过来」，用户�
 | 文件 | 职责 |
 |------|------|
 | `shared/ptyPlain.js` | `furnaceGuiTranscript` 累积清屏前可读帧；`takeFurnaceAssistantDelta` / `buildFurnaceChatTurns` |
-| `FurnaceWorkspace.vue` | GUI 对话框气泡；TUI 铺满原生终端，可选「记录」侧栏 |
-| `TerminalView.vue` | 原样 xterm（不吞备用屏，不强制 overflow 抢鼠标） |
+| `FurnaceWorkspace.vue` | GUI 对话框气泡 + 常显滚动条 |
+| `TerminalView.vue` | 熔炉 `preserveHistory`：备用屏不进 alt buffer，清屏前推入 scrollback |
 | `server/test/ptyPlain.test.js` | 去壳、跨屏历史、对话轮次 |

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -40,7 +40,7 @@ app.use(ElementPlusX)
 | 壳层顶栏 | `App.vue` + `AppLogo` | 品牌 Logo + 分段导航 |
 | 熔炉桌宠 | `FurnaceSprite` | 贴右、距底约三分之一；chatgpt-pets v2 图集按单帧人物区裁掉左右透明留白，不能把 192px 整格直接缩小；李慕婉 idle / running / waiting + 戳一下 waving，悬停注视；收起后仍是整个人 |
 | 熔炉干活面头像 | `FurnaceAvatar` | 仅 GUI 大头；开干活面时藏桌宠 |
-| 熔炉干活面 | `FurnaceWorkspace` | GUI/TUI 一张皮；**返回群聊**只关皮；顶栏「进程」里**关闭熔炉 / 新开熔炉**（新开会确认） |
+| 熔炉干活面 | `FurnaceWorkspace` | GUI 对话框气泡 / TUI 可上翻；**返回群聊**只关皮；顶栏「进程」里**关闭熔炉 / 新开熔炉** |
 | Logo | `components/AppLogo.vue` · `assets/logo.svg` | **左人 · 中文档 · 右机**（人机协同办公）；见 [brand-logo.md](./brand-logo.md) |
 | 左栏会话 | `Conversations` + 开聊条 | 群模板 / 成员分组下拉 → 开聊；`items` + `v-model:active` |
 | 中栏消息 | `BubbleList` | **`noStyle`** 去组件外壳；`#content` 内 `.bubble-rich` 单层气泡；`#header` 发送人、`#avatar` 首字 |

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -40,7 +40,7 @@ app.use(ElementPlusX)
 | 壳层顶栏 | `App.vue` + `AppLogo` | 品牌 Logo + 分段导航 |
 | 熔炉桌宠 | `FurnaceSprite` | 贴右、距底约三分之一；chatgpt-pets v2 图集按单帧人物区裁掉左右透明留白，不能把 192px 整格直接缩小；李慕婉 idle / running / waiting + 戳一下 waving，悬停注视；收起后仍是整个人 |
 | 熔炉干活面头像 | `FurnaceAvatar` | 仅 GUI 大头；开干活面时藏桌宠 |
-| 熔炉干活面 | `FurnaceWorkspace` | GUI 对话框气泡；TUI 为完整 Grok（可点按钮）；**返回群聊**只关皮；顶栏「进程」里**关闭熔炉 / 新开熔炉** |
+| 熔炉干活面 | `FurnaceWorkspace` | GUI 对话框气泡 / TUI 可上翻；**返回群聊**只关皮；顶栏「进程」里**关闭熔炉 / 新开熔炉** |
 | Logo | `components/AppLogo.vue` · `assets/logo.svg` | **左人 · 中文档 · 右机**（人机协同办公）；见 [brand-logo.md](./brand-logo.md) |
 | 左栏会话 | `Conversations` + 开聊条 | 群模板 / 成员分组下拉 → 开聊；`items` + `v-model:active` |
 | 中栏消息 | `BubbleList` | **`noStyle`** 去组件外壳；`#content` 内 `.bubble-rich` 单层气泡；`#header` 发送人、`#avatar` 首字 |

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -40,7 +40,7 @@ app.use(ElementPlusX)
 | 壳层顶栏 | `App.vue` + `AppLogo` | 品牌 Logo + 分段导航 |
 | 熔炉桌宠 | `FurnaceSprite` | 贴右、距底约三分之一；chatgpt-pets v2 图集按单帧人物区裁掉左右透明留白，不能把 192px 整格直接缩小；李慕婉 idle / running / waiting + 戳一下 waving，悬停注视；收起后仍是整个人 |
 | 熔炉干活面头像 | `FurnaceAvatar` | 仅 GUI 大头；开干活面时藏桌宠 |
-| 熔炉干活面 | `FurnaceWorkspace` | GUI 对话框气泡 / TUI 可上翻；**返回群聊**只关皮；顶栏「进程」里**关闭熔炉 / 新开熔炉** |
+| 熔炉干活面 | `FurnaceWorkspace` | GUI 对话框气泡；TUI 为完整 Grok（可点按钮）；**返回群聊**只关皮；顶栏「进程」里**关闭熔炉 / 新开熔炉** |
 | Logo | `components/AppLogo.vue` · `assets/logo.svg` | **左人 · 中文档 · 右机**（人机协同办公）；见 [brand-logo.md](./brand-logo.md) |
 | 左栏会话 | `Conversations` + 开聊条 | 群模板 / 成员分组下拉 → 开聊；`items` + `v-model:active` |
 | 中栏消息 | `BubbleList` | **`noStyle`** 去组件外壳；`#content` 内 `.bubble-rich` 单层气泡；`#header` 发送人、`#avatar` 首字 |

--- a/server/test/ptyPlain.test.js
+++ b/server/test/ptyPlain.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { renderPtyPlainText, furnaceGuiTranscript, furnaceGuiReadable } from '@acw/shared'
+import { renderPtyPlainText, furnaceGuiTranscript, furnaceGuiReadable, takeFurnaceAssistantDelta, buildFurnaceChatTurns } from '@acw/shared'
 
 test('carriage return overwrites the same line', () => {
   assert.equal(renderPtyPlainText('hello\rworld', { cols: 40, rows: 10 }), 'world')
@@ -63,16 +63,50 @@ test('chrome-only TUI is not treated as GUI body', () => {
   assert.equal(furnaceGuiReadable(text), false)
 })
 
-test('GUI last screen drops scrolled-off TUI frames', () => {
+test('GUI transcript keeps earlier readable frames after wipe', () => {
+  const raw =
+    '第一轮回答：这里有足够长的中文内容。\u001b[H\u001b[2J第二轮回答：后面又写了一段中文。'
+  const text = furnaceGuiTranscript(raw, { cols: 40, rows: 8 })
+  assert.match(text, /第一轮回答/)
+  assert.match(text, /第二轮回答/)
+})
+
+test('GUI transcript does not duplicate identical wipes', () => {
+  const frame = '同一段足够长的中文回答内容。'
+  const raw = `${frame}\u001b[H\u001b[2J${frame}\u001b[H\u001b[2J${frame}`
+  const text = furnaceGuiTranscript(raw, { cols: 40, rows: 8 })
+  assert.equal(text.split('同一段').length - 1, 1)
+})
+
+test('GUI last screen still drops chrome-only leftover frames', () => {
   const raw = `${'旧画面残留\n'.repeat(40)}\u001b[H\u001b[2J你好，这是当前屏。`
   const text = furnaceGuiTranscript(raw, { cols: 40, rows: 8 })
   assert.match(text, /当前屏/)
-  assert.equal(text.includes('旧画面残留'), false)
+  assert.match(text, /旧画面残留/)
 })
 
-test('alternate screen does not keep the previous buffer in GUI', () => {
-  const raw = `主缓冲旧字\u001b[?1049h\u001b[H\u001b[2J你好，备用屏。`
+test('alternate screen still keeps earlier readable buffer in GUI history', () => {
+  const raw = `主缓冲旧字也够长了。\u001b[?1049h\u001b[H\u001b[2J你好，备用屏上也有一段中文。`
   const text = furnaceGuiTranscript(raw, { cols: 40, rows: 8 })
   assert.match(text, /备用屏/)
-  assert.equal(text.includes('主缓冲'), false)
+  assert.match(text, /主缓冲旧字/)
+})
+
+test('assistant delta returns only the new tail', () => {
+  const prev = '第一轮足够长的中文内容。'
+  const curr = `${prev}\n第二轮足够长的中文内容。`
+  assert.equal(takeFurnaceAssistantDelta(curr, prev), '第二轮足够长的中文内容。')
+  assert.equal(takeFurnaceAssistantDelta(prev, prev), '')
+})
+
+test('chat turns split when user text appears in transcript', () => {
+  const turns = buildFurnaceChatTurns('你好，我是 Grok。\n现在做到哪了？只看当前格。\n当前格在写文档。', [
+    '现在做到哪了？只看当前格。',
+  ])
+  assert.equal(turns.length, 3)
+  assert.equal(turns[0].role, 'assistant')
+  assert.match(turns[0].text, /我是 Grok/)
+  assert.equal(turns[1].role, 'user')
+  assert.equal(turns[2].role, 'assistant')
+  assert.match(turns[2].text, /写文档/)
 })

--- a/shared/index.js
+++ b/shared/index.js
@@ -130,7 +130,14 @@ export function normalizeFurnaceSurface(v) {
     : FURNACE_SURFACE.CHAT
 }
 
-export { renderPtyPlainText, furnaceGuiTranscript, sanitizeFurnaceGuiText, furnaceGuiReadable } from './ptyPlain.js'
+export {
+  renderPtyPlainText,
+  furnaceGuiTranscript,
+  sanitizeFurnaceGuiText,
+  furnaceGuiReadable,
+  takeFurnaceAssistantDelta,
+  buildFurnaceChatTurns,
+} from './ptyPlain.js'
 
 /** 去 CSI / OSC，给卡片预览用；GUI 请用 furnaceGuiTranscript */
 export function stripAnsi(value) {

--- a/shared/ptyPlain.js
+++ b/shared/ptyPlain.js
@@ -33,6 +33,124 @@ function wcwidth(cp) {
   return 1
 }
 
+const BOX_CHARS = /[\u2500-\u257F\u2580-\u259F]/g
+
+const CHROME_LINE = [
+  /enter\s*:\s*send/i,
+  /alt\s*\+\s*enter/i,
+  /shift\s*\+\s*enter/i,
+  /shift\s*\+\s*tab/i,
+  /ctrl\s*\+\s*x\s*:/i,
+  /logged in with/i,
+  /always-approve/i,
+  /grok build beta/i,
+  /waiting for response/i,
+  /^\s*thinking\b/i,
+  /api key\s*\|/i,
+  /^\s*beta\s*$/i,
+  /^\s*(deepseek|claude|gpt-?4|grok)(\s|$)/i,
+]
+
+const HISTORY_MAX_LINES = 3000
+
+function hasCjk(s) {
+  return /[\u3400-\u9fff]/.test(s)
+}
+
+function isChromeLine(line) {
+  const stripped = line.replace(BOX_CHARS, '').replace(/[-+|═\s]/g, '')
+  if (!stripped) return true
+  const trimmed = line.replace(BOX_CHARS, '').trim()
+  if (!trimmed) return true
+  if (hasCjk(trimmed) && trimmed.length > 12) return false
+  if (CHROME_LINE.some((re) => re.test(line) || re.test(trimmed))) return true
+  if (!hasCjk(trimmed) && !/[a-zA-Z]{2,}/.test(trimmed) && trimmed.length < 12) return true
+  return false
+}
+
+/** 屏幕文本去掉 Grok TUI 壳，给 GUI 当正文 */
+export function sanitizeFurnaceGuiText(text) {
+  const src = String(text || '')
+  if (!src.trim()) return ''
+  const kept = []
+  for (const line of src.split('\n')) {
+    const noBox = line.replace(BOX_CHARS, ' ').replace(/[ \t]+/g, ' ').trim()
+    if (!noBox) continue
+    if (isChromeLine(line) || isChromeLine(noBox)) continue
+    if (!hasCjk(noBox) && noBox.length <= 3 && !/^[A-Za-z]{2,}$/.test(noBox)) continue
+    kept.push(noBox)
+  }
+  const out = []
+  for (const line of kept) {
+    if (!line) {
+      if (out.length && out[out.length - 1] !== '') out.push('')
+      continue
+    }
+    out.push(line)
+  }
+  while (out.length && !out[0]) out.shift()
+  while (out.length && !out[out.length - 1]) out.pop()
+  return out.join('\n')
+}
+
+/** 是否够当 GUI 正文（有中文句子或较长英文）。壳残片不当正文。 */
+export function furnaceGuiReadable(text) {
+  const t = String(text || '').trim()
+  if (!t) return false
+  const compact = t.replace(/\s+/g, '')
+  if (hasCjk(t) && compact.length >= 6) return true
+  if (t.length >= 28 && /[A-Za-z]{4,}/.test(t) && /\s/.test(t)) return true
+  return false
+}
+
+function keepHistoryFrame(text) {
+  const t = String(text || '').trim()
+  if (!t) return false
+  if (furnaceGuiReadable(t)) return true
+  const compact = t.replace(/\s+/g, '')
+  return hasCjk(t) && compact.length >= 4
+}
+
+function mergeHistoryLines(prev, nextLines) {
+  const next = (nextLines || []).map((l) => String(l || '').replace(/[ \t]+$/g, '')).filter((l) => l.length)
+  if (!next.length) return prev
+  if (!prev.length) return next.slice()
+  const prevText = prev.join('\n')
+  const nextText = next.join('\n')
+  if (prevText.includes(nextText)) return prev
+  if (nextText.includes(prevText)) return next.slice()
+  const maxK = Math.min(prev.length, next.length)
+  for (let k = maxK; k >= 1; k -= 1) {
+    let ok = true
+    for (let i = 0; i < k; i += 1) {
+      if (prev[prev.length - k + i] !== next[i]) {
+        ok = false
+        break
+      }
+    }
+    if (ok) return [...prev, ...next.slice(k)]
+  }
+  const last = prev[prev.length - 1]
+  const idx = next.indexOf(last)
+  if (idx >= 0) return [...prev, ...next.slice(idx + 1)]
+  const first = next[0]
+  const pidx = prev.lastIndexOf(first)
+  if (pidx >= 0) return [...prev.slice(0, pidx), ...next]
+  return [...prev, ...next]
+}
+
+function capHistory(lines) {
+  if (lines.length <= HISTORY_MAX_LINES) return lines
+  return lines.slice(-HISTORY_MAX_LINES)
+}
+
+function commitVisibleFrame(screen) {
+  const raw = screen.grid.map(rowToString).join('\n')
+  const clean = sanitizeFurnaceGuiText(raw)
+  if (!keepHistoryFrame(clean)) return
+  screen.historyLines = capHistory(mergeHistoryLines(screen.historyLines, clean.split('\n')))
+}
+
 function makeRow(cols) {
   return Array.from({ length: cols }, () => ' ')
 }
@@ -47,6 +165,7 @@ function createScreen(cols, rows) {
     rows,
     grid: Array.from({ length: rows }, () => makeRow(cols)),
     scrollback: [],
+    historyLines: [],
     cx: 0,
     cy: 0,
     alt: false,
@@ -65,6 +184,7 @@ function snapshotScreen(screen) {
 
 function enterAltScreen(screen) {
   if (screen.alt) return
+  commitVisibleFrame(screen)
   screen.saved = snapshotScreen(screen)
   screen.grid = Array.from({ length: screen.rows }, () => makeRow(screen.cols))
   screen.scrollback = []
@@ -99,7 +219,12 @@ function newline(screen) {
   screen.cx = 0
   screen.cy += 1
   if (screen.cy < screen.rows) return
-  screen.scrollback.push(rowToString(screen.grid[0]))
+  const scrolled = rowToString(screen.grid[0])
+  screen.scrollback.push(scrolled)
+  const clean = sanitizeFurnaceGuiText(scrolled)
+  if (keepHistoryFrame(clean)) {
+    screen.historyLines = capHistory(mergeHistoryLines(screen.historyLines, clean.split('\n')))
+  }
   screen.grid.shift()
   screen.grid.push(makeRow(screen.cols))
   screen.cy = screen.rows - 1
@@ -120,6 +245,7 @@ function eraseLine(screen, mode) {
 
 function eraseDisplay(screen, mode) {
   if (mode === 2 || mode === 3) {
+    commitVisibleFrame(screen)
     screen.grid = Array.from({ length: screen.rows }, () => makeRow(screen.cols))
     screen.cx = 0
     screen.cy = 0
@@ -297,77 +423,72 @@ export function renderPtyPlainText(value, opts = {}) {
   return tidyLines(lines, maxLines)
 }
 
-const BOX_CHARS = /[\u2500-\u257F\u2580-\u259F]/g
-
-const CHROME_LINE = [
-  /enter\s*:\s*send/i,
-  /alt\s*\+\s*enter/i,
-  /shift\s*\+\s*enter/i,
-  /shift\s*\+\s*tab/i,
-  /ctrl\s*\+\s*x\s*:/i,
-  /logged in with/i,
-  /always-approve/i,
-  /grok build beta/i,
-  /waiting for response/i,
-  /^\s*thinking\b/i,
-  /api key\s*\|/i,
-  /^\s*beta\s*$/i,
-  /^\s*(deepseek|claude|gpt-?4|grok)(\s|$)/i,
-]
-
-function hasCjk(s) {
-  return /[\u3400-\u9fff]/.test(s)
-}
-
-function isChromeLine(line) {
-  const stripped = line.replace(BOX_CHARS, '').replace(/[-+|═\s]/g, '')
-  if (!stripped) return true
-  const trimmed = line.replace(BOX_CHARS, '').trim()
-  if (!trimmed) return true
-  if (hasCjk(trimmed) && trimmed.length > 12) return false
-  if (CHROME_LINE.some((re) => re.test(line) || re.test(trimmed))) return true
-  if (!hasCjk(trimmed) && !/[a-zA-Z]{2,}/.test(trimmed) && trimmed.length < 12) return true
-  return false
-}
-
-/** 屏幕文本去掉 Grok TUI 壳，给 GUI 当正文 */
-export function sanitizeFurnaceGuiText(text) {
-  const src = String(text || '')
-  if (!src.trim()) return ''
-  const kept = []
-  for (const line of src.split('\n')) {
-    const noBox = line.replace(BOX_CHARS, ' ').replace(/[ \t]+/g, ' ').trim()
-    if (!noBox) continue
-    if (isChromeLine(line) || isChromeLine(noBox)) continue
-    if (!hasCjk(noBox) && noBox.length <= 3 && !/^[A-Za-z]{2,}$/.test(noBox)) continue
-    kept.push(noBox)
-  }
-  const out = []
-  for (const line of kept) {
-    if (!line) {
-      if (out.length && out[out.length - 1] !== '') out.push('')
-      continue
-    }
-    out.push(line)
-  }
-  while (out.length && !out[0]) out.shift()
-  while (out.length && !out[out.length - 1]) out.pop()
-  return out.join('\n')
-}
-
-/** 是否够当 GUI 正文（有中文句子或较长英文）。壳残片不当正文。 */
-export function furnaceGuiReadable(text) {
-  const t = String(text || '').trim()
-  if (!t) return false
-  const compact = t.replace(/\s+/g, '')
-  if (hasCjk(t) && compact.length >= 6) return true
-  if (t.length >= 28 && /[A-Za-z]{4,}/.test(t) && /\s/.test(t)) return true
-  return false
-}
-
-/** GUI 用：只取当前屏，再去壳，避免把旧 TUI 帧拼进聊天 */
+/** GUI 用：累积各次清屏前的可读正文，再去壳。不再只留当前一屏。 */
 export function furnaceGuiTranscript(value, opts = {}) {
-  return sanitizeFurnaceGuiText(
-    renderPtyPlainText(value, { ...opts, lastScreenOnly: true }),
-  )
+  const cols = clamp(opts.cols, 20, 300, 120)
+  const rows = clamp(opts.rows, 8, 80, 40)
+  const maxLines = clamp(opts.maxLines, 8, 8000, 2000)
+  const raw = String(value || '')
+  if (!raw) return ''
+  const screen = createScreen(cols, rows)
+  parse(raw, screen)
+  commitVisibleFrame(screen)
+  return tidyLines(screen.historyLines, maxLines)
+}
+
+/**
+ * 从整段累积正文里扣掉已经展示过的助手内容，得到本轮增量。
+ * Grok 全屏 TUI 会整屏重绘，所以不能只靠 startsWith。
+ */
+export function takeFurnaceAssistantDelta(fullText, alreadyShown) {
+  const curr = String(fullText || '').trim()
+  const prev = String(alreadyShown || '').trim()
+  if (!curr) return ''
+  if (!prev) return curr
+  if (curr === prev) return ''
+  if (curr.startsWith(prev)) return curr.slice(prev.length).replace(/^\s+/, '')
+  if (prev.startsWith(curr)) return ''
+  if (prev.includes(curr) && curr.length < prev.length) return ''
+  const currLines = curr.split('\n')
+  const prevLines = prev.split('\n')
+  const maxK = Math.min(currLines.length, prevLines.length)
+  for (let k = maxK; k >= 1; k -= 1) {
+    if (prevLines.slice(-k).join('\n') === currLines.slice(0, k).join('\n')) {
+      return currLines.slice(k).join('\n').trim()
+    }
+  }
+  const prevSet = new Set(prevLines.filter(Boolean))
+  const fresh = currLines.filter((line) => line && !prevSet.has(line))
+  return fresh.join('\n').trim()
+}
+
+/** 把累积正文和用户已发送文本拆成对话轮次（用户原文若出现在正文里则按出现位置切开） */
+export function buildFurnaceChatTurns(transcript, userMessages = []) {
+  const body = String(transcript || '').trim()
+  const users = (Array.isArray(userMessages) ? userMessages : [])
+    .map((m) => String(m || '').trim())
+    .filter(Boolean)
+  const turns = []
+  if (!users.length) {
+    if (body) turns.push({ role: 'assistant', text: body })
+    return turns
+  }
+  let rest = body
+  let split = false
+  for (const user of users) {
+    if (rest) {
+      const idx = rest.indexOf(user)
+      if (idx >= 0) {
+        const before = rest.slice(0, idx).trim()
+        if (before) turns.push({ role: 'assistant', text: before })
+        rest = rest.slice(idx + user.length).replace(/^\s+/, '')
+        split = true
+      }
+    }
+    turns.push({ role: 'user', text: user })
+  }
+  const after = rest.trim()
+  if (after) turns.push({ role: 'assistant', text: after })
+  else if (!split && body) turns.push({ role: 'assistant', text: body })
+  return turns
 }

--- a/web/src/components/terminal/FurnaceWorkspace.vue
+++ b/web/src/components/terminal/FurnaceWorkspace.vue
@@ -41,16 +41,6 @@
             TUI
           </button>
           <button
-            v-if="surface === 'tui'"
-            type="button"
-            class="furnace-btn"
-            :class="{ on: tuiShowLog }"
-            title="侧栏看 GUI 攒下的对话。默认关上，避免挡住 Grok 的可点按钮。"
-            @click="tuiShowLog = !tuiShowLog"
-          >
-            记录
-          </button>
-          <button
             type="button"
             class="furnace-btn"
             :title="
@@ -212,33 +202,29 @@
       </div>
 
       <div v-if="tuiEverShown" v-show="surface === 'tui'" class="furnace-tui">
+        <div v-if="chatTurns.length" ref="tuiHistEl" class="furnace-tui-history">
+          <div class="furnace-tui-history-head">可上翻的对话记录（同一条进程）</div>
+          <div
+            v-for="turn in chatTurns"
+            :key="`tui-${turn.id}`"
+            class="furnace-tui-line"
+            :class="turn.role === 'user' ? 'is-user' : 'is-assistant'"
+          >
+            <span>{{ turn.role === 'user' ? '你' : 'Grok' }}</span>
+            <pre>{{ turn.text }}</pre>
+          </div>
+        </div>
         <TerminalView
           :key="terminal.id"
           :terminal="terminal"
           :prefs="prefs"
           :active="surface === 'tui'"
+          preserve-history
           @input="$emit('input', $event)"
           @resize="$emit('resize', $event)"
           @gap="$emit('gap', $event)"
           @focus-change="onFocusChange"
         />
-        <aside v-if="tuiShowLog && chatTurns.length" class="furnace-tui-log">
-          <div class="furnace-tui-log-head">
-            <span>对话记录</span>
-            <button type="button" class="furnace-btn" @click="tuiShowLog = false">关闭</button>
-          </div>
-          <div ref="tuiHistEl" class="furnace-tui-log-body">
-            <div
-              v-for="turn in chatTurns"
-              :key="`tui-${turn.id}`"
-              class="furnace-tui-line"
-              :class="turn.role === 'user' ? 'is-user' : 'is-assistant'"
-            >
-              <span>{{ turn.role === 'user' ? '你' : 'Grok' }}</span>
-              <pre>{{ turn.text }}</pre>
-            </div>
-          </div>
-        </aside>
       </div>
 
       <footer class="furnace-foot">
@@ -285,7 +271,6 @@ const isPagefill = ref(props.defaultPagefill !== false)
 const surface = ref(props.defaultSurface === 'tui' ? 'tui' : 'chat')
 /** 首次进 TUI 再挂 xterm；之后用 v-show，避免每次切皮拆掉终端 */
 const tuiEverShown = ref(surface.value === 'tui')
-const tuiShowLog = ref(false)
 const focused = ref(false)
 const draft = ref('')
 const sent = ref([])
@@ -391,10 +376,10 @@ const footerHint = computed(() => {
   if (!isRunning.value) return '进程已结束 · 点「新开熔炉」开空对话；返回群聊只关皮'
   if (surface.value === 'chat') {
     return isPagefill.value
-      ? '对话框可上翻 · 长合同在文件里 · 菜单请切 TUI'
+      ? '对话框可上翻 · 长合同在文件里 · 模型菜单切 TUI 用键盘'
       : '已在三栏中栏 · 可再铺满页面'
   }
-  if (focused.value) return 'TUI 输入中 · Esc 退出焦点 · 菜单可点 · 对话历史上翻在 GUI'
+  if (focused.value) return 'TUI 输入中 · Esc 退出焦点 · 上方可上翻记录 · 菜单用键盘'
   if (isPagefill.value) return '再按 Esc 缩小回工作台'
   return '点 TUI 继续输入'
 })
@@ -581,11 +566,6 @@ function onKeydown(ev) {
     focused.value = false
     return
   }
-  if (tuiShowLog.value) {
-    ev.preventDefault()
-    tuiShowLog.value = false
-    return
-  }
   if (isPagefill.value) {
     ev.preventDefault()
     isPagefill.value = false
@@ -612,10 +592,6 @@ watch(
     nextTick(() => syncAssistantFromTranscript())
   },
 )
-
-watch(tuiShowLog, (on) => {
-  if (on) nextTick(scrollTuiHistory)
-})
 
 watch(surface, (mode) => {
   if (mode === 'tui') tuiEverShown.value = true
@@ -840,41 +816,24 @@ onUnmounted(() => {
 
 .furnace-tui {
   background: #17191f;
-  position: relative;
 }
 
-.furnace-tui-log {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  bottom: 8px;
-  z-index: 4;
-  width: min(22rem, 38%);
-  display: flex;
-  flex-direction: column;
-  border-radius: 12px;
-  background: rgba(22, 24, 30, 0.94);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
-  pointer-events: auto;
-}
-
-.furnace-tui-log-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px;
-  font-size: 12px;
-  color: #cfd4de;
+.furnace-tui-history {
+  flex: 0 1 42%;
+  min-height: 120px;
+  max-height: 46%;
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+  scrollbar-color: rgba(255, 255, 255, 0.4) rgba(255, 255, 255, 0.06);
+  padding: 8px 12px 10px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.furnace-tui-log-body {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding: 8px 10px 10px;
+.furnace-tui-history-head {
+  font-size: 11px;
+  color: #8b909a;
+  margin-bottom: 8px;
 }
 
 .furnace-tui-line {

--- a/web/src/components/terminal/FurnaceWorkspace.vue
+++ b/web/src/components/terminal/FurnaceWorkspace.vue
@@ -41,6 +41,16 @@
             TUI
           </button>
           <button
+            v-if="surface === 'tui'"
+            type="button"
+            class="furnace-btn"
+            :class="{ on: tuiShowLog }"
+            title="侧栏看 GUI 攒下的对话。默认关上，避免挡住 Grok 的可点按钮。"
+            @click="tuiShowLog = !tuiShowLog"
+          >
+            记录
+          </button>
+          <button
             type="button"
             class="furnace-btn"
             :title="
@@ -202,29 +212,33 @@
       </div>
 
       <div v-if="tuiEverShown" v-show="surface === 'tui'" class="furnace-tui">
-        <div v-if="chatTurns.length" ref="tuiHistEl" class="furnace-tui-history">
-          <div class="furnace-tui-history-head">可上翻的对话记录（同一条进程）</div>
-          <div
-            v-for="turn in chatTurns"
-            :key="`tui-${turn.id}`"
-            class="furnace-tui-line"
-            :class="turn.role === 'user' ? 'is-user' : 'is-assistant'"
-          >
-            <span>{{ turn.role === 'user' ? '你' : 'Grok' }}</span>
-            <pre>{{ turn.text }}</pre>
-          </div>
-        </div>
         <TerminalView
           :key="terminal.id"
           :terminal="terminal"
           :prefs="prefs"
           :active="surface === 'tui'"
-          preserve-history
           @input="$emit('input', $event)"
           @resize="$emit('resize', $event)"
           @gap="$emit('gap', $event)"
           @focus-change="onFocusChange"
         />
+        <aside v-if="tuiShowLog && chatTurns.length" class="furnace-tui-log">
+          <div class="furnace-tui-log-head">
+            <span>对话记录</span>
+            <button type="button" class="furnace-btn" @click="tuiShowLog = false">关闭</button>
+          </div>
+          <div ref="tuiHistEl" class="furnace-tui-log-body">
+            <div
+              v-for="turn in chatTurns"
+              :key="`tui-${turn.id}`"
+              class="furnace-tui-line"
+              :class="turn.role === 'user' ? 'is-user' : 'is-assistant'"
+            >
+              <span>{{ turn.role === 'user' ? '你' : 'Grok' }}</span>
+              <pre>{{ turn.text }}</pre>
+            </div>
+          </div>
+        </aside>
       </div>
 
       <footer class="furnace-foot">
@@ -271,6 +285,7 @@ const isPagefill = ref(props.defaultPagefill !== false)
 const surface = ref(props.defaultSurface === 'tui' ? 'tui' : 'chat')
 /** 首次进 TUI 再挂 xterm；之后用 v-show，避免每次切皮拆掉终端 */
 const tuiEverShown = ref(surface.value === 'tui')
+const tuiShowLog = ref(false)
 const focused = ref(false)
 const draft = ref('')
 const sent = ref([])
@@ -379,8 +394,8 @@ const footerHint = computed(() => {
       ? '对话框可上翻 · 长合同在文件里 · 菜单请切 TUI'
       : '已在三栏中栏 · 可再铺满页面'
   }
-  if (focused.value) return 'TUI 输入中 · Esc 退出焦点 · 右侧滚动条可上翻历史'
-  if (isPagefill.value) return '再按 Esc 缩小回工作台 · 右侧滚动条可上翻历史'
+  if (focused.value) return 'TUI 输入中 · Esc 退出焦点 · 菜单可点 · 对话历史上翻在 GUI'
+  if (isPagefill.value) return '再按 Esc 缩小回工作台'
   return '点 TUI 继续输入'
 })
 
@@ -566,6 +581,11 @@ function onKeydown(ev) {
     focused.value = false
     return
   }
+  if (tuiShowLog.value) {
+    ev.preventDefault()
+    tuiShowLog.value = false
+    return
+  }
   if (isPagefill.value) {
     ev.preventDefault()
     isPagefill.value = false
@@ -592,6 +612,10 @@ watch(
     nextTick(() => syncAssistantFromTranscript())
   },
 )
+
+watch(tuiShowLog, (on) => {
+  if (on) nextTick(scrollTuiHistory)
+})
 
 watch(surface, (mode) => {
   if (mode === 'tui') tuiEverShown.value = true
@@ -816,24 +840,41 @@ onUnmounted(() => {
 
 .furnace-tui {
   background: #17191f;
+  position: relative;
 }
 
-.furnace-tui-history {
-  flex: 0 1 42%;
-  min-height: 120px;
-  max-height: 46%;
-  overflow-y: scroll;
-  scrollbar-gutter: stable;
-  scrollbar-width: auto;
-  scrollbar-color: rgba(255, 255, 255, 0.4) rgba(255, 255, 255, 0.06);
-  padding: 8px 12px 10px;
+.furnace-tui-log {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  bottom: 8px;
+  z-index: 4;
+  width: min(22rem, 38%);
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  background: rgba(22, 24, 30, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+}
+
+.furnace-tui-log-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #cfd4de;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.furnace-tui-history-head {
-  font-size: 11px;
-  color: #8b909a;
-  margin-bottom: 8px;
+.furnace-tui-log-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px 10px 10px;
 }
 
 .furnace-tui-line {

--- a/web/src/components/terminal/FurnaceWorkspace.vue
+++ b/web/src/components/terminal/FurnaceWorkspace.vue
@@ -85,7 +85,7 @@
             <p class="furnace-buddy-credit" :title="PET_COPYRIGHT">{{ PET_CREDIT_SHORT }}</p>
             <p class="furnace-buddy-line">{{ buddyLine }}</p>
           </aside>
-          <div class="furnace-log-main">
+          <div class="furnace-thread">
             <div v-if="showFail" class="furnace-welcome is-fail">
               <p class="furnace-welcome-kicker">{{ welcomeKicker }}</p>
               <h3>Grok 没在跑，所以这里是空的</h3>
@@ -105,7 +105,7 @@
               <p class="furnace-welcome-kicker">{{ welcomeKicker }}</p>
               <h3>本机 Grok 已接进协同台</h3>
               <p>
-                同一条进程：这里读回答，菜单和模型在 TUI。细节在工作目录
+                同一条进程：这里是对话框，菜单和模型在 TUI。细节在工作目录
                 <code>AGENTS.md</code> / <code>ACTIVE.md</code>，不用整段粘贴。聊太长就「新开熔炉」。
               </p>
               <ul>
@@ -127,18 +127,29 @@
                 </button>
               </div>
             </div>
-            <div v-if="showBody" class="screen">
-              <span class="bubble-label">Grok · 可读正文</span>
-              <pre>{{ liveText }}</pre>
+            <div
+              v-for="turn in chatTurns"
+              :key="turn.id"
+              class="furnace-turn"
+              :class="turn.role === 'user' ? 'is-user' : 'is-assistant'"
+            >
+              <span class="furnace-turn-label">{{ turn.role === 'user' ? '你' : 'Grok' }}</span>
+              <div class="furnace-bubble">{{ turn.text }}</div>
+            </div>
+            <div v-if="awaitingReply" class="furnace-turn is-assistant is-pending">
+              <span class="furnace-turn-label">Grok</span>
+              <div class="furnace-bubble is-pending">正在写…</div>
             </div>
           </div>
         </div>
-        <div v-if="sent.length" class="furnace-sent">
-          <span class="furnace-sent-label">已写入进程</span>
-          <span v-for="item in sent.slice(-3)" :key="item.id" class="furnace-sent-chip">{{
-            item.text
-          }}</span>
-        </div>
+        <button
+          v-if="!stickBottom && chatTurns.length"
+          type="button"
+          class="furnace-jump-latest"
+          @click="jumpToLatest"
+        >
+          回到最新
+        </button>
         <form
           class="furnace-composer"
           @submit.prevent="sendChat"
@@ -196,6 +207,7 @@
           :terminal="terminal"
           :prefs="prefs"
           :active="surface === 'tui'"
+          preserve-history
           @input="$emit('input', $event)"
           @resize="$emit('resize', $event)"
           @gap="$emit('gap', $event)"
@@ -214,7 +226,7 @@
 
 <script setup>
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
-import { buildFurnacePtyAttachText, furnaceGuiTranscript, furnaceGuiReadable } from '@acw/shared'
+import { buildFurnacePtyAttachText, furnaceGuiTranscript, furnaceGuiReadable, takeFurnaceAssistantDelta } from '@acw/shared'
 import { ElMessage } from 'element-plus'
 import { api } from '../../api'
 import FurnaceAvatar from '../FurnaceAvatar.vue'
@@ -249,6 +261,7 @@ const tuiEverShown = ref(surface.value === 'tui')
 const focused = ref(false)
 const draft = ref('')
 const sent = ref([])
+const chatTurns = ref([])
 const pendingFiles = ref([])
 const uploading = ref(false)
 const uploadError = ref('')
@@ -270,12 +283,16 @@ const liveText = computed(() =>
   furnaceGuiTranscript(props.terminal.replay || '', {
     cols: props.terminal.cols || 120,
     rows: props.terminal.rows || 40,
-    maxLines: 40,
+    maxLines: 2000,
   }),
 )
-const showBody = computed(() => furnaceGuiReadable(liveText.value))
+const showBody = computed(() => furnaceGuiReadable(liveText.value) || chatTurns.value.length > 0)
 const showFail = computed(() => isStopped.value && !showBody.value)
 const showWelcome = computed(() => !showBody.value && !showFail.value)
+const awaitingReply = computed(() => {
+  if (!isRunning.value || !chatTurns.value.length) return false
+  return chatTurns.value[chatTurns.value.length - 1].role === 'user'
+})
 const failHint = computed(() => {
   const err = String(props.terminal.lastError || props.terminal.error?.message || '').trim()
   if (err) return err
@@ -316,9 +333,9 @@ const buddyTitle = computed(() => {
 })
 
 const buddyLine = computed(() => {
-  if (!isRunning.value) return '这轮停了。记录还在。'
+  if (!isRunning.value) return '这轮停了。记录还在，可上翻。'
   if (!showBody.value) return '她准备好后会先介绍，再等你。'
-  return '同一条 Grok。问当前格即可。'
+  return '同一条 Grok。问当前格即可。可上翻看更早的话。'
 })
 
 const welcomeKicker = computed(() => {
@@ -346,11 +363,11 @@ const footerHint = computed(() => {
   if (!isRunning.value) return '进程已结束 · 点「新开熔炉」开空对话；返回群聊只关皮'
   if (surface.value === 'chat') {
     return isPagefill.value
-      ? '可读正文 · 长合同在文件里 · 菜单请切 TUI'
+      ? '对话框可上翻 · 长合同在文件里 · 菜单请切 TUI'
       : '已在三栏中栏 · 可再铺满页面'
   }
-  if (focused.value) return 'TUI 输入中 · Esc 退出焦点'
-  if (isPagefill.value) return '再按 Esc 缩小回工作台'
+  if (focused.value) return 'TUI 输入中 · Esc 退出焦点 · 右侧滚动条可上翻历史'
+  if (isPagefill.value) return '再按 Esc 缩小回工作台 · 右侧滚动条可上翻历史'
   return '点 TUI 继续输入'
 })
 
@@ -371,10 +388,49 @@ function onFocusChange(value) {
   focused.value = !!value
 }
 
+function nextTurnId() {
+  return `${Date.now()}-${chatTurns.value.length}-${Math.random().toString(36).slice(2, 7)}`
+}
+
+function priorAssistantText() {
+  const items = chatTurns.value
+  const last = items[items.length - 1]
+  return items
+    .filter((t, i) => t.role === 'assistant' && !(last?.role === 'assistant' && i === items.length - 1))
+    .map((t) => t.text)
+    .join('\n')
+}
+
+function stripUserEchoes(text) {
+  let next = String(text || '')
+  for (const item of sent.value) {
+    const u = String(item.text || '').trim()
+    if (!u) continue
+    next = next.split(u).join('')
+  }
+  return next.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
+}
+
+function syncAssistantFromTranscript() {
+  const text = liveText.value
+  if (!furnaceGuiReadable(text)) return
+  const last = chatTurns.value[chatTurns.value.length - 1]
+  const body = stripUserEchoes(takeFurnaceAssistantDelta(text, priorAssistantText()))
+  if (!body || !furnaceGuiReadable(body)) return
+  if (last?.role === 'assistant') last.text = body
+  else chatTurns.value.push({ id: nextTurnId(), role: 'assistant', text: body })
+}
+
+function jumpToLatest() {
+  stickBottom.value = true
+  nextTick(scrollLog)
+}
+
 function sendChat() {
   const payload = buildFurnacePtyAttachText(draft.value, pendingFiles.value)
   if (!payload || !isRunning.value || uploading.value) return
   sent.value.push({ id: `${Date.now()}-${sent.value.length}`, text: payload })
+  chatTurns.value.push({ id: nextTurnId(), role: 'user', text: payload })
   emit('input', `${payload}\r`)
   draft.value = ''
   pendingFiles.value = []
@@ -489,7 +545,19 @@ watch(isPagefill, async (on) => {
   requestAnimationFrame(() => window.dispatchEvent(new Event('resize')))
 })
 
-watch(liveText, () => nextTick(scrollLog))
+watch(liveText, () => {
+  syncAssistantFromTranscript()
+  nextTick(scrollLog)
+})
+
+watch(
+  () => props.terminal.id,
+  () => {
+    chatTurns.value = []
+    sent.value = []
+    nextTick(() => syncAssistantFromTranscript())
+  },
+)
 
 watch(surface, (mode) => {
   if (mode === 'tui') tuiEverShown.value = true
@@ -521,6 +589,7 @@ onMounted(() => {
   syncFullscreenState()
   if (isPagefill.value) document.documentElement.classList.add('acw-terminal-pagefill')
   if (surface.value === 'chat') emit('resize', { cols: 120, rows: 40 })
+  syncAssistantFromTranscript()
   nextTick(scrollLog)
 })
 
@@ -708,21 +777,45 @@ onUnmounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .furnace-tui {
   background: #17191f;
 }
 
+.furnace-tui :deep(.terminal-view) {
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
 .furnace-log {
   flex: 1;
   min-height: 0;
-  overflow: auto;
-  padding: 20px 6% 12px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+  scrollbar-color: rgba(60, 60, 67, 0.45) transparent;
+  padding: 20px 4% 16px;
   display: grid;
   grid-template-columns: 128px minmax(0, 1fr);
   gap: 20px 16px;
   align-items: start;
+}
+
+.furnace-log::-webkit-scrollbar {
+  width: 10px;
+}
+
+.furnace-log::-webkit-scrollbar-thumb {
+  background: rgba(60, 60, 67, 0.38);
+  border-radius: 8px;
+}
+
+.furnace-log::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.04);
 }
 
 .furnace-buddy {
@@ -750,8 +843,13 @@ onUnmounted(() => {
   color: #6e6e73;
 }
 
-.furnace-log-main {
+.furnace-thread {
   min-width: 0;
+  max-width: 46rem;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 8px;
 }
 
 .furnace-empty {
@@ -764,7 +862,7 @@ onUnmounted(() => {
 
 .furnace-welcome {
   max-width: 40rem;
-  margin: 4vh 0 0;
+  margin: 0;
   padding: 18px 20px 16px;
   border-radius: 18px;
   background: #fff;
@@ -835,58 +933,74 @@ onUnmounted(() => {
   cursor: not-allowed;
 }
 
-.screen {
-  max-width: min(56rem, 100%);
-  margin: 0 auto 16px;
+.furnace-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 100%;
 }
 
-.bubble-label {
-  display: block;
+.furnace-turn.is-user {
+  align-items: flex-end;
+}
+
+.furnace-turn.is-assistant {
+  align-items: flex-start;
+}
+
+.furnace-turn-label {
   font-size: 11px;
   font-weight: 650;
   color: #6e6e73;
-  margin-bottom: 6px;
+  padding: 0 6px;
 }
 
-.screen pre {
+.furnace-bubble {
+  max-width: min(40rem, 100%);
   margin: 0;
-  padding: 16px 18px;
-  border-radius: 16px;
+  padding: 12px 16px;
+  border-radius: 18px;
   white-space: pre-wrap;
-  overflow-wrap: break-word;
-  word-break: normal;
-  font-family: 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', ui-sans-serif, system-ui, sans-serif;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   font-size: 15px;
   line-height: 1.7;
-  background: #fff;
-  color: #1d1d1f;
   box-shadow: 0 1px 8px rgba(0, 0, 0, 0.06);
 }
 
-.furnace-sent {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 8% 0;
+.furnace-turn.is-assistant .furnace-bubble {
+  background: #fff;
+  color: #1d1d1f;
+  border-bottom-left-radius: 6px;
 }
 
-.furnace-sent-label {
-  font-size: 11px;
+.furnace-turn.is-user .furnace-bubble {
+  background: #007aff;
+  color: #fff;
+  border-bottom-right-radius: 6px;
+  box-shadow: 0 1px 8px rgba(0, 122, 255, 0.22);
+}
+
+.furnace-bubble.is-pending {
   color: #6e6e73;
-  flex-shrink: 0;
+  font-style: italic;
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.72);
 }
 
-.furnace-sent-chip {
-  max-width: 28rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  padding: 4px 10px;
+.furnace-jump-latest {
+  position: absolute;
+  right: 22px;
+  bottom: 118px;
+  z-index: 3;
+  border: 0;
   border-radius: 999px;
-  background: rgba(0, 122, 255, 0.1);
-  color: #007aff;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  background: rgba(29, 29, 31, 0.82);
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
 }
 
 .furnace-composer {

--- a/web/src/components/terminal/FurnaceWorkspace.vue
+++ b/web/src/components/terminal/FurnaceWorkspace.vue
@@ -202,6 +202,18 @@
       </div>
 
       <div v-if="tuiEverShown" v-show="surface === 'tui'" class="furnace-tui">
+        <div v-if="chatTurns.length" ref="tuiHistEl" class="furnace-tui-history">
+          <div class="furnace-tui-history-head">可上翻的对话记录（同一条进程）</div>
+          <div
+            v-for="turn in chatTurns"
+            :key="`tui-${turn.id}`"
+            class="furnace-tui-line"
+            :class="turn.role === 'user' ? 'is-user' : 'is-assistant'"
+          >
+            <span>{{ turn.role === 'user' ? '你' : 'Grok' }}</span>
+            <pre>{{ turn.text }}</pre>
+          </div>
+        </div>
         <TerminalView
           :key="terminal.id"
           :terminal="terminal"
@@ -253,6 +265,7 @@ const emit = defineEmits(['close', 'kill', 'close-furnace', 'reopen', 'input', '
 
 const workspaceRoot = ref(null)
 const logEl = ref(null)
+const tuiHistEl = ref(null)
 const isFullscreen = ref(false)
 const isPagefill = ref(props.defaultPagefill !== false)
 const surface = ref(props.defaultSurface === 'tui' ? 'tui' : 'chat')
@@ -401,6 +414,16 @@ function priorAssistantText() {
     .join('\n')
 }
 
+function collapseDupBlocks(text) {
+  const parts = String(text || '').split(/\n{2,}/).map((p) => p.trim()).filter(Boolean)
+  const out = []
+  for (const p of parts) {
+    if (out[out.length - 1] === p) continue
+    out.push(p)
+  }
+  return out.join('\n\n')
+}
+
 function stripUserEchoes(text) {
   let next = String(text || '')
   for (const item of sent.value) {
@@ -408,14 +431,18 @@ function stripUserEchoes(text) {
     if (!u) continue
     next = next.split(u).join('')
   }
-  return next.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
+  next = next
+    .split('\n')
+    .filter((line) => !/^\s*你[：:]\s*/.test(line))
+    .join('\n')
+  return collapseDupBlocks(next.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim())
 }
 
 function syncAssistantFromTranscript() {
   const text = liveText.value
   if (!furnaceGuiReadable(text)) return
   const last = chatTurns.value[chatTurns.value.length - 1]
-  const body = stripUserEchoes(takeFurnaceAssistantDelta(text, priorAssistantText()))
+  const body = collapseDupBlocks(stripUserEchoes(takeFurnaceAssistantDelta(text, priorAssistantText())))
   if (!body || !furnaceGuiReadable(body)) return
   if (last?.role === 'assistant') last.text = body
   else chatTurns.value.push({ id: nextTurnId(), role: 'assistant', text: body })
@@ -521,6 +548,12 @@ function scrollLog() {
   el.scrollTop = el.scrollHeight
 }
 
+function scrollTuiHistory() {
+  const el = tuiHistEl.value
+  if (!el) return
+  el.scrollTop = el.scrollHeight
+}
+
 function onKeydown(ev) {
   if (ev.key !== 'Escape') return
   if (surface.value === 'chat' && document.activeElement?.tagName === 'TEXTAREA') {
@@ -548,6 +581,7 @@ watch(isPagefill, async (on) => {
 watch(liveText, () => {
   syncAssistantFromTranscript()
   nextTick(scrollLog)
+  nextTick(scrollTuiHistory)
 })
 
 watch(
@@ -784,6 +818,55 @@ onUnmounted(() => {
   background: #17191f;
 }
 
+.furnace-tui-history {
+  flex: 0 1 42%;
+  min-height: 120px;
+  max-height: 46%;
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+  scrollbar-color: rgba(255, 255, 255, 0.4) rgba(255, 255, 255, 0.06);
+  padding: 8px 12px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.furnace-tui-history-head {
+  font-size: 11px;
+  color: #8b909a;
+  margin-bottom: 8px;
+}
+
+.furnace-tui-line {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.furnace-tui-line span {
+  color: #8b909a;
+  font-size: 11px;
+  padding-top: 2px;
+}
+
+.furnace-tui-line.is-user span {
+  color: #64a9ff;
+}
+
+.furnace-tui-line pre {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: #e7e9ee;
+  font-family: inherit;
+}
+
+.furnace-tui-line.is-user pre {
+  color: #c9ddff;
+}
+
 .furnace-tui :deep(.terminal-view) {
   flex: 1;
   min-height: 0;
@@ -797,12 +880,12 @@ onUnmounted(() => {
   overflow-x: hidden;
   scrollbar-gutter: stable;
   scrollbar-width: auto;
-  scrollbar-color: rgba(60, 60, 67, 0.45) transparent;
-  padding: 20px 4% 16px;
+  scrollbar-color: rgba(60, 60, 67, 0.55) rgba(0, 0, 0, 0.06);
+  padding: 16px 3% 12px;
   display: grid;
-  grid-template-columns: 128px minmax(0, 1fr);
-  gap: 20px 16px;
-  align-items: start;
+  grid-template-columns: 104px minmax(0, 1fr);
+  gap: 16px 14px;
+  align-items: stretch;
 }
 
 .furnace-log::-webkit-scrollbar {
@@ -845,11 +928,13 @@ onUnmounted(() => {
 
 .furnace-thread {
   min-width: 0;
-  max-width: 46rem;
+  max-width: 44rem;
+  min-height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding-bottom: 8px;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-bottom: 4px;
 }
 
 .furnace-empty {

--- a/web/src/components/terminal/TerminalView.vue
+++ b/web/src/components/terminal/TerminalView.vue
@@ -15,7 +15,6 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { TERMINAL_THEMES, defaultTerminalPrefs } from './terminalPrefs'
-import { sanitizeFurnaceGuiText } from '@acw/shared'
 
 const props = defineProps({
   terminal: { type: Object, required: true },
@@ -34,8 +33,6 @@ let xterm = null
 let fitAddon = null
 let resizeObserver = null
 let lastSeq = 0
-let lastHistoryPush = ''
-let pushingHistory = false
 const historyDisposables = []
 
 function paramAt(params, index) {
@@ -56,32 +53,7 @@ function paramsHas(params, code) {
   return false
 }
 
-function readViewportText(term) {
-  const buf = term.buffer?.active
-  if (!buf) return ''
-  const lines = []
-  const top = Number(buf.viewportY) || 0
-  for (let i = 0; i < term.rows; i += 1) {
-    const line = buf.getLine(top + i)
-    lines.push(line ? line.translateToString(true) : '')
-  }
-  return lines.join('\n')
-}
-
-function pushViewportToScrollback(term) {
-  if (!term || pushingHistory) return
-  const clean = sanitizeFurnaceGuiText(readViewportText(term))
-  if (!clean || clean === lastHistoryPush) return
-  lastHistoryPush = clean
-  pushingHistory = true
-  try {
-    const n = Math.max(1, Number(term.rows) || 24)
-    term.write(`\x1b[${n};1H${'\r\n'.repeat(n)}`)
-  } finally {
-    pushingHistory = false
-  }
-}
-
+/** 不进备用屏，对话才能留在主缓冲的 scrollback 里；禁止在 CSI 回调里 write，避免回放时把画面冲掉 */
 function attachHistoryPreservation(term) {
   const parser = term.parser
   if (!parser?.registerCsiHandler) return
@@ -94,13 +66,6 @@ function attachHistoryPreservation(term) {
   historyDisposables.push(
     parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
       if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
-      return false
-    }),
-  )
-  historyDisposables.push(
-    parser.registerCsiHandler({ final: 'J' }, (params) => {
-      const mode = paramAt(params, 0) || 0
-      if (mode === 2 || mode === 3) pushViewportToScrollback(term)
       return false
     }),
   )
@@ -124,7 +89,6 @@ function fit() {
 
 function resetToReplay(value) {
   if (!xterm) return
-  lastHistoryPush = ''
   const text = String(value || '')
   xterm.reset()
   if (text) xterm.write(text)

--- a/web/src/components/terminal/TerminalView.vue
+++ b/web/src/components/terminal/TerminalView.vue
@@ -21,8 +21,6 @@ const props = defineProps({
   prefs: { type: Object, default: () => ({}) },
   /** 隐藏时禁止 fit，避免把 PTY 缩成几列 */
   active: { type: Boolean, default: true },
-  /** 熔炉：吞掉备用屏，清屏前把当前画面推进滚动历史，才能上翻看到更早的话 */
-  preserveHistory: { type: Boolean, default: false },
 })
 
 const isRunning = computed(() => ['starting', 'running'].includes(props.terminal.status))
@@ -33,43 +31,6 @@ let xterm = null
 let fitAddon = null
 let resizeObserver = null
 let lastSeq = 0
-const historyDisposables = []
-
-function paramAt(params, index) {
-  if (!params) return 0
-  if (typeof params.get === 'function') {
-    const v = params.get(index)
-    return Array.isArray(v) ? v[0] : Number(v) || 0
-  }
-  const v = params[index]
-  return Array.isArray(v) ? v[0] : Number(v) || 0
-}
-
-function paramsHas(params, code) {
-  const n = Number(params?.length) || 0
-  for (let i = 0; i < n; i += 1) {
-    if (paramAt(params, i) === code) return true
-  }
-  return false
-}
-
-/** 不进备用屏，对话才能留在主缓冲的 scrollback 里；禁止在 CSI 回调里 write，避免回放时把画面冲掉 */
-function attachHistoryPreservation(term) {
-  const parser = term.parser
-  if (!parser?.registerCsiHandler) return
-  historyDisposables.push(
-    parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
-      if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
-      return false
-    }),
-  )
-  historyDisposables.push(
-    parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
-      if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
-      return false
-    }),
-  )
-}
 
 function fit() {
   if (!xterm || !fitAddon || !host.value?.isConnected) return
@@ -107,15 +68,12 @@ onMounted(async () => {
     fontSize: Number(prefs.fontSize) || 13,
     lineHeight: 1.3,
     letterSpacing: 0,
-    scrollback: props.preserveHistory
-      ? Math.max(Number(prefs.scrollback) || 5000, 8000)
-      : Number(prefs.scrollback) || 5000,
+    scrollback: Number(prefs.scrollback) || 5000,
     theme,
   })
   fitAddon = new FitAddon()
   xterm.loadAddon(fitAddon)
   xterm.open(host.value)
-  if (props.preserveHistory) attachHistoryPreservation(xterm)
   xterm.onData((data) => {
     if (!isRunning.value) return
     const lineBreaks = (data.match(/[\r\n]/g) || []).length
@@ -165,7 +123,6 @@ watch(
 )
 
 onBeforeUnmount(() => {
-  historyDisposables.splice(0).forEach((d) => d?.dispose?.())
   resizeObserver?.disconnect()
   resizeObserver = null
   xterm?.dispose()
@@ -188,23 +145,8 @@ onBeforeUnmount(() => {
 }
 
 .terminal-view :deep(.xterm-viewport) {
-  overflow-y: scroll !important;
-  scrollbar-gutter: stable;
-  scrollbar-color: rgba(255, 255, 255, 0.42) rgba(255, 255, 255, 0.06);
-  scrollbar-width: auto;
-}
-
-.terminal-view :deep(.xterm-viewport::-webkit-scrollbar) {
-  width: 10px;
-}
-
-.terminal-view :deep(.xterm-viewport::-webkit-scrollbar-thumb) {
-  background: rgba(255, 255, 255, 0.38);
-  border-radius: 8px;
-}
-
-.terminal-view :deep(.xterm-viewport::-webkit-scrollbar-track) {
-  background: rgba(255, 255, 255, 0.06);
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-width: thin;
 }
 
 .terminal-view.is-dead {

--- a/web/src/components/terminal/TerminalView.vue
+++ b/web/src/components/terminal/TerminalView.vue
@@ -21,6 +21,8 @@ const props = defineProps({
   prefs: { type: Object, default: () => ({}) },
   /** 隐藏时禁止 fit，避免把 PTY 缩成几列 */
   active: { type: Boolean, default: true },
+  /** 熔炉：吞掉备用屏，清屏前把当前画面推进滚动历史，才能上翻看到更早的话 */
+  preserveHistory: { type: Boolean, default: false },
 })
 
 const isRunning = computed(() => ['starting', 'running'].includes(props.terminal.status))
@@ -31,6 +33,43 @@ let xterm = null
 let fitAddon = null
 let resizeObserver = null
 let lastSeq = 0
+const historyDisposables = []
+
+function paramAt(params, index) {
+  if (!params) return 0
+  if (typeof params.get === 'function') {
+    const v = params.get(index)
+    return Array.isArray(v) ? v[0] : Number(v) || 0
+  }
+  const v = params[index]
+  return Array.isArray(v) ? v[0] : Number(v) || 0
+}
+
+function paramsHas(params, code) {
+  const n = Number(params?.length) || 0
+  for (let i = 0; i < n; i += 1) {
+    if (paramAt(params, i) === code) return true
+  }
+  return false
+}
+
+/** 不进备用屏，对话才能留在主缓冲的 scrollback 里；禁止在 CSI 回调里 write，避免回放时把画面冲掉 */
+function attachHistoryPreservation(term) {
+  const parser = term.parser
+  if (!parser?.registerCsiHandler) return
+  historyDisposables.push(
+    parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
+      if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
+      return false
+    }),
+  )
+  historyDisposables.push(
+    parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
+      if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
+      return false
+    }),
+  )
+}
 
 function fit() {
   if (!xterm || !fitAddon || !host.value?.isConnected) return
@@ -68,12 +107,15 @@ onMounted(async () => {
     fontSize: Number(prefs.fontSize) || 13,
     lineHeight: 1.3,
     letterSpacing: 0,
-    scrollback: Number(prefs.scrollback) || 5000,
+    scrollback: props.preserveHistory
+      ? Math.max(Number(prefs.scrollback) || 5000, 8000)
+      : Number(prefs.scrollback) || 5000,
     theme,
   })
   fitAddon = new FitAddon()
   xterm.loadAddon(fitAddon)
   xterm.open(host.value)
+  if (props.preserveHistory) attachHistoryPreservation(xterm)
   xterm.onData((data) => {
     if (!isRunning.value) return
     const lineBreaks = (data.match(/[\r\n]/g) || []).length
@@ -123,6 +165,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
+  historyDisposables.splice(0).forEach((d) => d?.dispose?.())
   resizeObserver?.disconnect()
   resizeObserver = null
   xterm?.dispose()
@@ -145,8 +188,23 @@ onBeforeUnmount(() => {
 }
 
 .terminal-view :deep(.xterm-viewport) {
-  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
-  scrollbar-width: thin;
+  overflow-y: scroll !important;
+  scrollbar-gutter: stable;
+  scrollbar-color: rgba(255, 255, 255, 0.42) rgba(255, 255, 255, 0.06);
+  scrollbar-width: auto;
+}
+
+.terminal-view :deep(.xterm-viewport::-webkit-scrollbar) {
+  width: 10px;
+}
+
+.terminal-view :deep(.xterm-viewport::-webkit-scrollbar-thumb) {
+  background: rgba(255, 255, 255, 0.38);
+  border-radius: 8px;
+}
+
+.terminal-view :deep(.xterm-viewport::-webkit-scrollbar-track) {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .terminal-view.is-dead {

--- a/web/src/components/terminal/TerminalView.vue
+++ b/web/src/components/terminal/TerminalView.vue
@@ -15,12 +15,15 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { TERMINAL_THEMES, defaultTerminalPrefs } from './terminalPrefs'
+import { sanitizeFurnaceGuiText } from '@acw/shared'
 
 const props = defineProps({
   terminal: { type: Object, required: true },
   prefs: { type: Object, default: () => ({}) },
   /** 隐藏时禁止 fit，避免把 PTY 缩成几列 */
   active: { type: Boolean, default: true },
+  /** 熔炉：吞掉备用屏，清屏前把当前画面推进滚动历史，才能上翻看到更早的话 */
+  preserveHistory: { type: Boolean, default: false },
 })
 
 const isRunning = computed(() => ['starting', 'running'].includes(props.terminal.status))
@@ -31,6 +34,77 @@ let xterm = null
 let fitAddon = null
 let resizeObserver = null
 let lastSeq = 0
+let lastHistoryPush = ''
+let pushingHistory = false
+const historyDisposables = []
+
+function paramAt(params, index) {
+  if (!params) return 0
+  if (typeof params.get === 'function') {
+    const v = params.get(index)
+    return Array.isArray(v) ? v[0] : Number(v) || 0
+  }
+  const v = params[index]
+  return Array.isArray(v) ? v[0] : Number(v) || 0
+}
+
+function paramsHas(params, code) {
+  const n = Number(params?.length) || 0
+  for (let i = 0; i < n; i += 1) {
+    if (paramAt(params, i) === code) return true
+  }
+  return false
+}
+
+function readViewportText(term) {
+  const buf = term.buffer?.active
+  if (!buf) return ''
+  const lines = []
+  const top = Number(buf.viewportY) || 0
+  for (let i = 0; i < term.rows; i += 1) {
+    const line = buf.getLine(top + i)
+    lines.push(line ? line.translateToString(true) : '')
+  }
+  return lines.join('\n')
+}
+
+function pushViewportToScrollback(term) {
+  if (!term || pushingHistory) return
+  const clean = sanitizeFurnaceGuiText(readViewportText(term))
+  if (!clean || clean === lastHistoryPush) return
+  lastHistoryPush = clean
+  pushingHistory = true
+  try {
+    const n = Math.max(1, Number(term.rows) || 24)
+    term.write(`\x1b[${n};1H${'\r\n'.repeat(n)}`)
+  } finally {
+    pushingHistory = false
+  }
+}
+
+function attachHistoryPreservation(term) {
+  const parser = term.parser
+  if (!parser?.registerCsiHandler) return
+  historyDisposables.push(
+    parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
+      if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
+      return false
+    }),
+  )
+  historyDisposables.push(
+    parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
+      if (paramsHas(params, 1049) || paramsHas(params, 1047) || paramsHas(params, 47)) return true
+      return false
+    }),
+  )
+  historyDisposables.push(
+    parser.registerCsiHandler({ final: 'J' }, (params) => {
+      const mode = paramAt(params, 0) || 0
+      if (mode === 2 || mode === 3) pushViewportToScrollback(term)
+      return false
+    }),
+  )
+}
 
 function fit() {
   if (!xterm || !fitAddon || !host.value?.isConnected) return
@@ -50,6 +124,7 @@ function fit() {
 
 function resetToReplay(value) {
   if (!xterm) return
+  lastHistoryPush = ''
   const text = String(value || '')
   xterm.reset()
   if (text) xterm.write(text)
@@ -68,12 +143,15 @@ onMounted(async () => {
     fontSize: Number(prefs.fontSize) || 13,
     lineHeight: 1.3,
     letterSpacing: 0,
-    scrollback: Number(prefs.scrollback) || 5000,
+    scrollback: props.preserveHistory
+      ? Math.max(Number(prefs.scrollback) || 5000, 8000)
+      : Number(prefs.scrollback) || 5000,
     theme,
   })
   fitAddon = new FitAddon()
   xterm.loadAddon(fitAddon)
   xterm.open(host.value)
+  if (props.preserveHistory) attachHistoryPreservation(xterm)
   xterm.onData((data) => {
     if (!isRunning.value) return
     const lineBreaks = (data.match(/[\r\n]/g) || []).length
@@ -123,6 +201,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
+  historyDisposables.splice(0).forEach((d) => d?.dispose?.())
   resizeObserver?.disconnect()
   resizeObserver = null
   xterm?.dispose()
@@ -145,8 +224,23 @@ onBeforeUnmount(() => {
 }
 
 .terminal-view :deep(.xterm-viewport) {
-  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
-  scrollbar-width: thin;
+  overflow-y: scroll !important;
+  scrollbar-gutter: stable;
+  scrollbar-color: rgba(255, 255, 255, 0.42) rgba(255, 255, 255, 0.06);
+  scrollbar-width: auto;
+}
+
+.terminal-view :deep(.xterm-viewport::-webkit-scrollbar) {
+  width: 10px;
+}
+
+.terminal-view :deep(.xterm-viewport::-webkit-scrollbar-thumb) {
+  background: rgba(255, 255, 255, 0.38);
+  border-radius: 8px;
+}
+
+.terminal-view :deep(.xterm-viewport::-webkit-scrollbar-track) {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .terminal-view.is-dead {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Grok 全屏 TUI 每次清屏只留下当前一屏，GUI 原先只导出这一屏，所以看起来像滚动条坏了。

## GUI
累积可读正文；左右对话框气泡（你在右、Grok 在左），可上翻。

## TUI
上方同一份可滚动对话记录，下方活终端。为了能上翻会吞备用屏，**Grok 画面里的可点按钮可能点不准，用键盘即可，不再为点击去拆历史。**

`npm test` 覆盖跨屏历史与去壳。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ce92090-908f-4522-bd68-94f2b9ba2b39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ce92090-908f-4522-bd68-94f2b9ba2b39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

