### PR TITLE
第三栏文档中心工具栏窄宽换行

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,11 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-09-07 | M | web/src/views/workbench/components/FlowRail.vue | 第三栏文档中心工具栏改为可换行，标题 nowrap 避免被挤成竖排
+2026-09-07 | A | web/test/docsRailLayout.test.mjs | 锁文档中心工具栏换行契约
+2026-09-07 | A | scripts/selftest-docs-rail-toolbar.mjs | Playwright 测窄栏标题横排、按钮换行
+2026-09-07 | M | docs/selftest.md | 补文档中心工具栏布局用例与自测脚本
+
 2026-09-07 | M | packages/CURRENT.txt packages/README.md packages/oh-my-co-work-v4-*.build.json packages/oh-my-co-work-v4-*.zip | 三平台（linux-x64、win32-x64、darwin-arm64）4.2.0 运行包全量重新打包并通过 validate 校验
 2026-09-07 | M | eslint.config.js | 忽略打包临时目录 release/**，保证代码静态检查 0 error
 2026-09-07 | M | README.md | 文档同步：已实现功能与路线图补充 4.2.1（文档中心解耦与三栏内嵌、设置页一键备份/导出、熔炉元数据卡片化美化与下载安全加固）

--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,7 +22,7 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
-2026-09-07 | M | web/src/views/workbench/components/FlowRail.vue | 第三栏文档中心工具栏改为可换行，标题 nowrap 避免被挤成竖排
+2026-09-07 | M | web/src/views/workbench/components/FlowRail.vue | 第三栏文档中心工具栏改为可换行，标题 nowrap；换行后按钮左对齐
 2026-09-07 | A | web/test/docsRailLayout.test.mjs | 锁文档中心工具栏换行契约
 2026-09-07 | A | scripts/selftest-docs-rail-toolbar.mjs | Playwright 测窄栏标题横排、按钮换行
 2026-09-07 | M | docs/selftest.md | 补文档中心工具栏布局用例与自测脚本

--- a/docs/selftest.md
+++ b/docs/selftest.md
@@ -10,8 +10,8 @@
 | 层 | 位置 | 工具 | 规模 | 跑法 |
 |----|------|------|------|------|
 | 服务端单元/集成 | `server/test/*.test.js`（25 文件） | Node 内置 `node:test` + `node:assert/strict` | **139 例** | `npm test` |
-| 前端纯逻辑 | `web/test/*.test.mjs`（3 文件） | 同上（浏览器不用开） | **23 例** | `npm run test:web` |
-| 自愈/冒烟脚本 | `scripts/selftest-*.mjs` + `test-enter-send.mjs` | 独立脚本，**不走 test runner** | 4 + 1 个 | `node scripts/selftest-xxx.mjs` |
+| 前端纯逻辑 | `web/test/*.test.mjs`（4 文件） | 同上（浏览器不用开） | **24 例** | `npm run test:web` |
+| 自愈/冒烟脚本 | `scripts/selftest-*.mjs` + `test-enter-send.mjs` | 独立脚本，**不走 test runner** | 5 + 1 个 | `node scripts/selftest-xxx.mjs` |
 | 静态核查 | ESLint + 模板绑定核查 | eslint 9 / 临时脚本 | 0 error 基线 | `npm run lint` |
 | 发布自测 | CI + 打包流水线 | GitHub Actions | 每次推 main | 自动 |
 
@@ -112,7 +112,7 @@ assert.equal(/<a [^>]*javascript:/i.test(render('[点我](javascript:alert(1))')
 
 ## 5. 自愈/冒烟脚本（selftest-\*.mjs）
 
-`scripts/selftest-forward-jump.mjs`、`selftest-session-ops.mjs`、`selftest-v1-priority.mjs`、`selftest-v1-stability.mjs`——**不走 test runner**，是独立长流程脚本（起真实服务/跑完整流），用于手工自愈验证与发版前巡检。另有 `test-enter-send.mjs`（输入框回车发送的单点验证）。与单测的分工：单测管"单元语义不变"，selftest 管"整条流程能走通"。**注意**：这类脚本默认针对真实运行中的服务与真实数据（如 `selftest-session-ops` 断言库里已有群模板），不要在含重要数据的实例上随手跑。
+`scripts/selftest-forward-jump.mjs`、`selftest-session-ops.mjs`、`selftest-v1-priority.mjs`、`selftest-v1-stability.mjs`、`selftest-docs-rail-toolbar.mjs`——**不走 test runner**。前四个是独立长流程脚本（起真实服务/跑完整流）；`selftest-docs-rail-toolbar.mjs` 用 Playwright 测第三栏文档中心工具栏窄宽换行（标题不竖排）。另有 `test-enter-send.mjs`（输入框回车发送的单点验证）。与单测的分工：单测管"单元语义不变"，selftest 管"整条流程能走通"。**注意**：长流程脚本默认针对真实运行中的服务与真实数据（如 `selftest-session-ops` 断言库里已有群模板），不要在含重要数据的实例上随手跑。
 
 ---
 

--- a/scripts/selftest-docs-rail-toolbar.mjs
+++ b/scripts/selftest-docs-rail-toolbar.mjs
@@ -1,0 +1,113 @@
+/**
+ * 工作台第三栏文档中心工具栏：窄宽换行，标题保持横排。
+ * Usage: node scripts/selftest-docs-rail-toolbar.mjs
+ */
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const vueSrc = fs.readFileSync(
+  path.join(root, 'web/src/views/workbench/components/FlowRail.vue'),
+  'utf8',
+)
+const styleMatch = vueSrc.match(/<style scoped>([\s\S]*?)<\/style>/)
+if (!styleMatch) throw new Error('FlowRail.vue 缺少 style')
+const docsCss = [...styleMatch[1].matchAll(/\.(docs-rail-[\w-]+)[\s\S]*?\}/g)]
+  .map((m) => m[0])
+  .join('\n')
+const artifactDir = '/opt/cursor/artifacts'
+
+const html = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+body { margin: 0; font-family: system-ui, sans-serif; background: #ece8f4; }
+.frame {
+  width: 268px;
+  padding: 10px;
+  background: rgba(255,255,255,0.55);
+  border-radius: 14px;
+}
+.docs-rail-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: #4a7dff;
+  flex-shrink: 0;
+}
+.docs-rail-actions button {
+  border: 1px solid rgba(0,0,0,0.12);
+  background: #fff;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+${docsCss}
+</style>
+</head>
+<body>
+<div class="frame">
+  <div class="docs-rail-toolbar" id="toolbar">
+    <div class="docs-rail-title-wrap" id="title-wrap">
+      <div class="docs-rail-logo"></div>
+      <span class="docs-rail-title" id="title">文档中心</span>
+    </div>
+    <div class="docs-rail-actions" id="actions">
+      <button type="button">新标签打开</button>
+      <button type="button">导出群</button>
+      <button type="button">刷新</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>`
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage({ viewport: { width: 400, height: 240 } })
+  await page.setContent(html, { waitUntil: 'load' })
+
+  const metrics = await page.evaluate(`(() => {
+    const title = document.getElementById('title')
+    const wrap = document.getElementById('title-wrap')
+    const actions = document.getElementById('actions')
+    const toolbar = document.getElementById('toolbar')
+    const t = title.getBoundingClientRect()
+    const a = actions.getBoundingClientRect()
+    const tb = toolbar.getBoundingClientRect()
+    return {
+      titleHeight: Math.round(t.height),
+      titleWidth: Math.round(t.width),
+      titleText: getComputedStyle(title).whiteSpace,
+      wrapWidth: Math.round(wrap.getBoundingClientRect().width),
+      actionsTop: Math.round(a.top),
+      titleTop: Math.round(t.top),
+      toolbarHeight: Math.round(tb.height),
+      wrapped: a.top > t.bottom - 2,
+    }
+  })()`)
+
+  assert.equal(metrics.titleText, 'nowrap', `标题应 nowrap ${JSON.stringify(metrics)}`)
+  assert.ok(metrics.titleHeight <= 24, `标题不应竖排叠字 ${JSON.stringify(metrics)}`)
+  assert.ok(metrics.titleWidth >= 48, `标题应横向排开 ${JSON.stringify(metrics)}`)
+  assert.equal(metrics.wrapped, true, `窄栏按钮应换到下一行 ${JSON.stringify(metrics)}`)
+  console.log('DOCS_RAIL_WRAP_OK', metrics)
+
+  try {
+    fs.mkdirSync(artifactDir, { recursive: true })
+    await page.screenshot({ path: path.join(artifactDir, 'docs_rail_toolbar_wrap.png') })
+  } catch {
+    /* 产物目录不可写时跳过 */
+  }
+
+  await browser.close()
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/selftest-docs-rail-toolbar.mjs
+++ b/scripts/selftest-docs-rail-toolbar.mjs
@@ -27,8 +27,8 @@ const html = `<!doctype html>
 <style>
 body { margin: 0; font-family: system-ui, sans-serif; background: #ece8f4; }
 .frame {
-  width: 268px;
-  padding: 10px;
+  width: 260px;
+  padding: 10px 0;
   background: rgba(255,255,255,0.55);
   border-radius: 14px;
 }
@@ -68,7 +68,7 @@ ${docsCss}
 
 async function main() {
   const browser = await chromium.launch({ headless: true })
-  const page = await browser.newPage({ viewport: { width: 400, height: 240 } })
+  const page = await browser.newPage({ viewport: { width: 300, height: 160 } })
   await page.setContent(html, { waitUntil: 'load' })
 
   const metrics = await page.evaluate(`(() => {
@@ -84,6 +84,8 @@ async function main() {
       titleWidth: Math.round(t.width),
       titleText: getComputedStyle(title).whiteSpace,
       wrapWidth: Math.round(wrap.getBoundingClientRect().width),
+      actionsLeft: Math.round(a.left),
+      toolbarLeft: Math.round(tb.left),
       actionsTop: Math.round(a.top),
       titleTop: Math.round(t.top),
       toolbarHeight: Math.round(tb.height),
@@ -95,6 +97,10 @@ async function main() {
   assert.ok(metrics.titleHeight <= 24, `标题不应竖排叠字 ${JSON.stringify(metrics)}`)
   assert.ok(metrics.titleWidth >= 48, `标题应横向排开 ${JSON.stringify(metrics)}`)
   assert.equal(metrics.wrapped, true, `窄栏按钮应换到下一行 ${JSON.stringify(metrics)}`)
+  assert.ok(
+    Math.abs(metrics.actionsLeft - metrics.toolbarLeft) <= 4,
+    `换行后按钮应左对齐 ${JSON.stringify(metrics)}`,
+  )
   console.log('DOCS_RAIL_WRAP_OK', metrics)
 
   try {

--- a/web/src/views/workbench/components/FlowRail.vue
+++ b/web/src/views/workbench/components/FlowRail.vue
@@ -1410,8 +1410,8 @@ watch(
 
 .docs-rail-toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
   margin-bottom: 10px;
   gap: 8px;
   flex-shrink: 0;
@@ -1421,6 +1421,8 @@ watch(
   display: flex;
   align-items: center;
   gap: 6px;
+  flex: 1 0 auto;
+  min-width: max-content;
 }
 
 .docs-rail-logo {
@@ -1432,12 +1434,16 @@ watch(
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--ecw-text-1, #1d1d1f);
+  white-space: nowrap;
 }
 
 .docs-rail-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
-  flex-shrink: 0;
+  flex: 1 1 14rem;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 .docs-rail-body {

--- a/web/src/views/workbench/components/FlowRail.vue
+++ b/web/src/views/workbench/components/FlowRail.vue
@@ -1421,8 +1421,8 @@ watch(
   display: flex;
   align-items: center;
   gap: 6px;
-  flex: 1 0 auto;
   min-width: max-content;
+  margin-right: auto;
 }
 
 .docs-rail-logo {
@@ -1441,8 +1441,6 @@ watch(
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
-  flex: 1 1 14rem;
-  justify-content: flex-end;
   min-width: 0;
 }
 

--- a/web/test/docsRailLayout.test.mjs
+++ b/web/test/docsRailLayout.test.mjs
@@ -14,6 +14,7 @@ test('第三栏文档中心工具栏窄宽时换行，标题不竖排', () => {
   assert.match(vueSrc, /\.docs-rail-toolbar \{[^}]*flex-wrap:\s*wrap/)
   assert.match(vueSrc, /\.docs-rail-title \{[^}]*white-space:\s*nowrap/)
   assert.match(vueSrc, /\.docs-rail-title-wrap \{[^}]*min-width:\s*max-content/)
+  assert.match(vueSrc, /\.docs-rail-title-wrap \{[^}]*margin-right:\s*auto/)
   assert.match(vueSrc, /\.docs-rail-actions \{[^}]*flex-wrap:\s*wrap/)
   assert.doesNotMatch(vueSrc, /\.docs-rail-actions \{[^}]*flex-shrink:\s*0/)
 })

--- a/web/test/docsRailLayout.test.mjs
+++ b/web/test/docsRailLayout.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const vueSrc = fs.readFileSync(
+  path.join(root, 'src/views/workbench/components/FlowRail.vue'),
+  'utf8',
+)
+
+test('第三栏文档中心工具栏窄宽时换行，标题不竖排', () => {
+  assert.match(vueSrc, /\.docs-rail-toolbar \{[^}]*flex-wrap:\s*wrap/)
+  assert.match(vueSrc, /\.docs-rail-title \{[^}]*white-space:\s*nowrap/)
+  assert.match(vueSrc, /\.docs-rail-title-wrap \{[^}]*min-width:\s*max-content/)
+  assert.match(vueSrc, /\.docs-rail-actions \{[^}]*flex-wrap:\s*wrap/)
+  assert.doesNotMatch(vueSrc, /\.docs-rail-actions \{[^}]*flex-shrink:\s*0/)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 做了什么

工作台第三栏「文档中心」标题和按钮挤在一行里，窄的时候「文档中心」会变成竖排字。

- 工具栏允许换行
- 标题 `nowrap`，不再被挤成一字一行
- 按钮空间不够就折到下一行，并从左边排（右栏内容宽大约 260px）

## 验证

- `web/test/docsRailLayout.test.mjs` 锁 CSS 契约
- `scripts/selftest-docs-rail-toolbar.mjs` 用 Playwright 在 260px 下断言标题横排、按钮换行且左对齐

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62de459f-7ab0-4f69-85ad-730855813c68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62de459f-7ab0-4f69-85ad-730855813c68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

