### PR TITLE
fix: 修复 4.7/4.8 进程登记目录与引擎事件静默失败

### DIFF
--- a/server/src/engine.js
+++ b/server/src/engine.js
@@ -8,6 +8,7 @@
 //   gates → (store/offsite/archive/adapterEvents/sessionLifecycle/advance)
 //   mentions → (store/offsite)
 //   userInput → (store/offsite/archive/gates/mentions)
+import './engine/listeners.js'
 
 export {
   pruneIdleOffsitePlaceholders,
@@ -44,40 +45,3 @@ export { handleGateAction } from './engine/gates.js'
 export { parseMemberMentions, invokeMentionedMembers } from './engine/mentions.js'
 
 export { postUserMessage } from './engine/userInput.js'
-
-import { engineBus } from './engine/events.js'
-import { emitSession, emitAll } from './bus.js'
-
-engineBus.on('ws_broadcast_session', (sessionId, payload) => {
-  emitSession(sessionId, payload)
-})
-
-engineBus.on('ws_broadcast_all', (payload) => {
-  emitAll(payload)
-})
-
-engineBus.on('update_node', (nodeId, patch) => {
-  updateNode(nodeId, patch)
-})
-
-// ------------------------------------------------------------------
-// EngineListener: 集中处理状态持久化等副作用，解耦 Engine 内部的 db 依赖
-// Phase 4.8.0 目标：统一状态持久化
-// ------------------------------------------------------------------
-import { updateSession, persistNodeIo, addMessage, updateMessageContent, updateNode } from './engine/store.js'
-
-engineBus.on('persist_session', (sessionId, patch) => {
-  updateSession(sessionId, patch)
-})
-
-engineBus.on('persist_node_io', (sessionId, nodeId, ioData) => {
-  persistNodeIo(sessionId, nodeId, ioData)
-})
-
-engineBus.on('add_message', (sessionId, msg) => {
-  addMessage(sessionId, msg)
-})
-
-engineBus.on('update_message', (messageId, content) => {
-  updateMessageContent(messageId, content)
-})

--- a/server/src/engine/adapterEvents.js
+++ b/server/src/engine/adapterEvents.js
@@ -2,7 +2,7 @@
 // Failures must not throw into the PTY watcher.
 // Imports: store, archive (below advance/gates in the engine DAG).
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import { SESSION_STATUS, nowIso } from '@acw/shared'
 import { appendAdapterReply } from '../terminal/adapters/jsonl.js'
 import { getSession } from './store.js'
@@ -21,7 +21,7 @@ export function applyAdapterEvent({
   if (!session || session.status === SESSION_STATUS.ARCHIVED) return
   try {
     if (event.type === 'message') {
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: event.role === 'user' ? 'user' : 'assistant',
         member_id: memberId || null,
         node_instance_id: nodeInstanceId || null,
@@ -32,7 +32,7 @@ export function applyAdapterEvent({
     }
     if (event.type === 'tool.start' || event.type === 'tool.end') {
       const started = event.type === 'tool.start'
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'assistant',
         member_id: memberId || null,
         node_instance_id: nodeInstanceId || null,
@@ -65,8 +65,8 @@ export function applyAdapterEvent({
         memberId: memberId || null,
       })
       ctx.pendingAdapterQuestions = pending
-      engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'gate',
         node_instance_id: nodeInstanceId || null,
@@ -81,7 +81,7 @@ export function applyAdapterEvent({
           humanAction: 'pending',
         },
       })
-      engineBus.emit('ws_broadcast_session', sessionId, {
+      engineEmit('ws_broadcast_session', sessionId, {
         type: 'gate.request',
         payload: {
           mode: 'adapter_question',
@@ -93,7 +93,7 @@ export function applyAdapterEvent({
       return
     }
     if (event.type === 'result') {
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'assistant',
         member_id: memberId || null,
         node_instance_id: nodeInstanceId || null,
@@ -109,7 +109,7 @@ export function applyAdapterEvent({
         const node = getDb().prepare('SELECT * FROM node_instances WHERE id = ?').get(nodeInstanceId)
         if (node) {
           const prev = parseJson(node.output_json, {})
-          engineBus.emit('update_node', nodeInstanceId, {
+          engineEmit('update_node', nodeInstanceId, {
             output_json: JSON.stringify({
               ...prev,
               adapterResult: {
@@ -164,7 +164,7 @@ export function answerAdapterQuestion(sessionId, { questionId, text, choice, act
     }
   }
   ctx.pendingAdapterQuestions = pending.filter((item) => item.id !== q.id)
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
   const row = getDb()
     .prepare(
       `SELECT * FROM messages WHERE session_id = ? AND type = 'gate' ORDER BY created_at DESC`,
@@ -173,14 +173,14 @@ export function answerAdapterQuestion(sessionId, { questionId, text, choice, act
     .find((m) => parseJson(m.content_json, {})?.questionId === q.id)
   if (row) {
     const content = parseJson(row.content_json, {})
-    engineBus.emit('update_message', row.id, {
+    engineEmit('update_message', row.id, {
       ...content,
       humanAction: action === 'reject' ? 'reject' : 'approve',
       answered: true,
       answer: answerText,
     })
   }
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'user',
     type: 'gate',
     node_instance_id: q.nodeInstanceId || null,

--- a/server/src/engine/advance.js
+++ b/server/src/engine/advance.js
@@ -1,7 +1,7 @@
 // advance() 主循环：节点推进、成员执行、审核闸门打开。
 // Imports: store, archive (sessionLifecycle/gates sit above and import from here).
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import { runMember } from '../runners.js'
 import {
   killSessionProcesses,
@@ -54,23 +54,23 @@ export async function advance(sessionId) {
     const node = nodes.find((n) => n.step_index === idx)
     if (!node) {
       idx += 1
-      engineBus.emit('persist_session', sessionId, { current_step_index: idx })
+      engineEmit('persist_session', sessionId, { current_step_index: idx })
       continue
     }
 
     if (node.status === NODE_STATUS.SUCCEEDED || node.status === NODE_STATUS.SKIPPED) {
       idx += 1
-      engineBus.emit('persist_session', sessionId, { current_step_index: idx })
+      engineEmit('persist_session', sessionId, { current_step_index: idx })
       continue
     }
 
     if (node.status === NODE_STATUS.WAITING_HUMAN) {
-      engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN, current_step_index: idx })
+      engineEmit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN, current_step_index: idx })
       return
     }
 
     if (node.status === NODE_STATUS.RUNNING) {
-      engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.ACTIVE, current_step_index: idx })
+      engineEmit('persist_session', sessionId, { status: SESSION_STATUS.ACTIVE, current_step_index: idx })
       return
     }
 
@@ -78,14 +78,14 @@ export async function advance(sessionId) {
     if (node.step_type === STEP_TYPE.ARCHIVE) {
       skipArchiveNode(sessionId, node, 'completed')
       idx += 1
-      engineBus.emit('persist_session', sessionId, { current_step_index: idx })
+      engineEmit('persist_session', sessionId, { current_step_index: idx })
       continue
     }
 
     // 额外节点：可插在流程中间；走到此处则挂起（如中途点外卖），不自动跳过
     if (node.step_type === STEP_TYPE.OFFSITE) {
       const title = node.title || '临时协助'
-      engineBus.emit('persist_node_io', sessionId, node.id, {
+      engineEmit('persist_node_io', sessionId, node.id, {
         input: {
           kind: 'offsite',
           prompt: title,
@@ -100,7 +100,7 @@ export async function advance(sessionId) {
         },
         status: NODE_STATUS.WAITING_HUMAN,
       })
-      engineBus.emit('persist_session', sessionId, {
+      engineEmit('persist_session', sessionId, {
         status: SESSION_STATUS.WAITING_HUMAN,
         current_step_index: idx,
       })
@@ -112,9 +112,9 @@ export async function advance(sessionId) {
         mode: OFFSITE_MODE.PLANNED,
         planned: true,
       }
-      engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+      engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
       touchFurnaceWorkflow(sessionId, { nodeId: node.id, keepRole: true })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         node_instance_id: node.id,
@@ -124,7 +124,7 @@ export async function advance(sessionId) {
           mode: OFFSITE_MODE.PLANNED,
         },
       })
-      engineBus.emit('ws_broadcast_session', sessionId, {
+      engineEmit('ws_broadcast_session', sessionId, {
         type: 'session.status',
         payload: {
           sessionId,
@@ -138,10 +138,10 @@ export async function advance(sessionId) {
     }
 
     // run step
-    engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.ACTIVE, current_step_index: idx })
-    engineBus.emit('update_node', node.id, { status: NODE_STATUS.RUNNING, started_at: nowIso() })
+    engineEmit('persist_session', sessionId, { status: SESSION_STATUS.ACTIVE, current_step_index: idx })
+    engineEmit('update_node', node.id, { status: NODE_STATUS.RUNNING, started_at: nowIso() })
     touchFurnaceWorkflow(sessionId, { nodeId: node.id, keepRole: true })
-    engineBus.emit('ws_broadcast_session', sessionId, {
+    engineEmit('ws_broadcast_session', sessionId, {
       type: 'session.status',
       payload: { sessionId, status: SESSION_STATUS.ACTIVE, currentStepIndex: idx },
     })
@@ -174,7 +174,7 @@ export async function advance(sessionId) {
       const prompt = captureParams
         ? `${basePrompt}\n（空格或换行分隔多段 → #1、#2…；同会话内递增追加，不覆盖；新开聊另起一套。节点输出整段不切分）`
         : basePrompt
-      engineBus.emit('persist_node_io', sessionId, node.id, {
+      engineEmit('persist_node_io', sessionId, node.id, {
         input: {
           kind: 'human',
           prompt: basePrompt,
@@ -184,9 +184,9 @@ export async function advance(sessionId) {
         output: { waiting: true, ...(cloneMeta || {}) },
         status: NODE_STATUS.WAITING_HUMAN,
       })
-      engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN })
+      engineEmit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN })
       touchFurnaceWorkflow(sessionId, { nodeId: node.id, keepRole: true })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'gate',
         node_instance_id: node.id,
@@ -197,7 +197,7 @@ export async function advance(sessionId) {
           actions: ['submit'],
         },
       })
-      engineBus.emit('ws_broadcast_session', sessionId, {
+      engineEmit('ws_broadcast_session', sessionId, {
         type: 'gate.request',
         payload: {
           nodeInstanceId: node.id,
@@ -212,13 +212,13 @@ export async function advance(sessionId) {
     // member step
     const member = node.member_id ? getMember(node.member_id) : null
     if (!member) {
-      engineBus.emit('persist_node_io', sessionId, node.id, {
+      engineEmit('persist_node_io', sessionId, node.id, {
         input: { memberId: node.member_id },
         output: { error: '成员不存在' },
         status: NODE_STATUS.FAILED,
         finished: true,
       })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'text',
         node_instance_id: node.id,
@@ -242,7 +242,7 @@ export async function advance(sessionId) {
     }
 
     if (memberNeedsProjectParams(member) && !hasProjectParam1(ctx)) {
-      engineBus.emit('persist_node_io', sessionId, node.id, {
+      engineEmit('persist_node_io', sessionId, node.id, {
         input: {
           memberId: member.id,
           memberName: member.display_name,
@@ -257,8 +257,8 @@ export async function advance(sessionId) {
         },
         status: NODE_STATUS.WAITING_HUMAN,
       })
-      engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN })
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'gate',
         node_instance_id: node.id,
@@ -270,7 +270,7 @@ export async function advance(sessionId) {
           policy: '缺 #1 时不启动脚本。闸门重试时本轮输入全文会作为 ACW_HUMAN_INPUT，不强制再切 #1。',
         },
       })
-      engineBus.emit('ws_broadcast_session', sessionId, {
+      engineEmit('ws_broadcast_session', sessionId, {
         type: 'gate.request',
         payload: {
           nodeInstanceId: node.id,
@@ -303,7 +303,7 @@ export async function advance(sessionId) {
             role: furnaceRole,
             nodeId: node.id,
           })
-          engineBus.emit('add_message', sessionId, {
+          engineEmit('add_message', sessionId, {
             role: 'system',
             type: 'status',
             node_instance_id: node.id,
@@ -330,7 +330,7 @@ export async function advance(sessionId) {
         }
       }
       runMemberAs = adaptPrep.member || member
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         node_instance_id: node.id,
@@ -358,13 +358,13 @@ export async function advance(sessionId) {
           }
         : {}),
     }
-    engineBus.emit('persist_node_io', sessionId, node.id, {
+    engineEmit('persist_node_io', sessionId, node.id, {
       input: memberInput,
       output: { running: true },
       status: NODE_STATUS.RUNNING,
     })
 
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'member',
       member_id: member.id,
       type: 'text',
@@ -419,7 +419,7 @@ export async function advance(sessionId) {
             refineFormatted: refineOut.formatted,
           }
         : memberInput
-    engineBus.emit('persist_node_io', sessionId, node.id, {
+    engineEmit('persist_node_io', sessionId, node.id, {
       input: refineInput,
       output: result,
       status: result.ok ? NODE_STATUS.SUCCEEDED : NODE_STATUS.FAILED,
@@ -428,7 +428,7 @@ export async function advance(sessionId) {
     touchFurnaceWorkflow(sessionId, { nodeId: node.id, keepRole: true })
 
     if (refineOut.source !== 'none') {
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         node_instance_id: node.id,
@@ -445,7 +445,7 @@ export async function advance(sessionId) {
       try {
         const killed = killMemberProcesses(sessionId, member.id)
         if (killed.killed > 0) {
-          engineBus.emit('add_message', sessionId, {
+          engineEmit('add_message', sessionId, {
             role: 'system',
             type: 'status',
             content: {
@@ -458,7 +458,7 @@ export async function advance(sessionId) {
       }
     }
 
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'member',
       member_id: member.id,
       type: result.ok ? 'text' : 'text',
@@ -530,7 +530,7 @@ export async function advance(sessionId) {
 
     // 三项全关：默认直接流转，避免卡死
     idx += 1
-    engineBus.emit('persist_session', sessionId, { current_step_index: idx })
+    engineEmit('persist_session', sessionId, { current_step_index: idx })
   }
 
   // 全部步骤完成：群聊默认归档释放资源；成员单聊（adhoc）保持进行中
@@ -562,7 +562,7 @@ function finishMainlineIfComplete(sessionId) {
     dismissPendingArchiveIfAny(sessionId, 'completed')
     const s = getSession(sessionId)
     if (s && s.status !== SESSION_STATUS.ARCHIVED && s.status !== SESSION_STATUS.INTERRUPTED) {
-      engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.ACTIVE })
+      engineEmit('persist_session', sessionId, { status: SESSION_STATUS.ACTIVE })
     }
     return
   }
@@ -571,11 +571,10 @@ function finishMainlineIfComplete(sessionId) {
 
 /** 打开流转闸门（人工/管理员）；审核态先置 pending */
 export function openFlowGate(sessionId, node, payload) {
-  engineBus.emit('update_node', node.id, { status: NODE_STATUS.WAITING_HUMAN })
-  engineBus.emit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN })
+  engineEmit('persist_session', sessionId, { status: SESSION_STATUS.WAITING_HUMAN })
   // 把 flow/votes 记在节点 output，便于同意时合并
   const prev = parseJson(node.output_json, {})
-  engineBus.emit('update_node', node.id, {
+  engineEmit('update_node', node.id, {
     status: NODE_STATUS.WAITING_HUMAN,
     output_json: JSON.stringify({
       ...prev,
@@ -590,7 +589,7 @@ export function openFlowGate(sessionId, node, payload) {
       humanAction: 'pending',
     }),
   })
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'gate',
     node_instance_id: node.id,
@@ -616,7 +615,7 @@ export function openFlowGate(sessionId, node, payload) {
         role: FURNACE_ROLE.REVIEW,
         nodeId: node.id,
       })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         node_instance_id: node.id,
@@ -629,7 +628,7 @@ export function openFlowGate(sessionId, node, payload) {
   } else {
     touchFurnaceWorkflow(sessionId, { nodeId: node.id, keepRole: true })
   }
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'gate.request',
     payload: {
       nodeInstanceId: node.id,

--- a/server/src/engine/archive.js
+++ b/server/src/engine/archive.js
@@ -1,7 +1,7 @@
 // 归档 / 解档 / 中断标记 / 群报告台账。
 // Imports: store, offsite (below advance/gates in the engine DAG).
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import {
   NODE_STATUS,
   SESSION_STATUS,
@@ -37,7 +37,7 @@ export function ensureArchiveTailNode(sessionId) {
 export function skipArchiveNode(sessionId, node, reason = 'completed') {
   if (!node) return
   if (node.status === NODE_STATUS.SUCCEEDED || node.status === NODE_STATUS.SKIPPED) return
-  engineBus.emit('persist_node_io', sessionId, node.id, {
+  engineEmit('persist_node_io', sessionId, node.id, {
     input: { kind: 'archive', skipped: true, reason },
     output: { skipped: true, skipReason: 'settings_release', reason },
     status: NODE_STATUS.SKIPPED,
@@ -78,7 +78,7 @@ export function dismissPendingArchiveIfAny(sessionId, reason = 'completed') {
         ? SESSION_STATUS.FAILED
         : SESSION_STATUS.ACTIVE
   }
-  engineBus.emit('persist_session', sessionId, patch)
+  engineEmit('persist_session', sessionId, patch)
   return null
 }
 
@@ -90,7 +90,7 @@ function markArchiveNodeDone(sessionId, { reason, note } = {}) {
     .get(sessionId, STEP_TYPE.ARCHIVE)
   if (!node) return null
   const prev = parseJson(node.output_json, {})
-  engineBus.emit('persist_node_io', sessionId, node.id, {
+  engineEmit('persist_node_io', sessionId, node.id, {
     input: parseJson(node.input_json, { kind: 'archive' }),
     output: {
       ...prev,
@@ -200,8 +200,8 @@ export function refreshSessionAnnouncement(sessionId, opts = {}) {
     ctx.announcementUpdatedAt = new Date().toISOString()
     ctx.announcementManual = false
     ctx.announcementModes = usedModes || ['concise']
-    engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
-    engineBus.emit('ws_broadcast_session', sessionId, {
+    engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+    engineEmit('ws_broadcast_session', sessionId, {
       type: 'announcement.updated',
       payload: { sessionId, path: rel, modes: usedModes, manual: false },
     })
@@ -221,13 +221,13 @@ export function saveSessionAnnouncement(sessionId, markdown) {
   ctx.announcementPath = rel
   ctx.announcementUpdatedAt = new Date().toISOString()
   ctx.announcementManual = true
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'announcement.updated',
     payload: { sessionId, path: rel, manual: true },
   })
   // 聊天里留一条系统提示（可选、轻量）
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'status',
     content: { text: '群报告已由人工更新', announcement: true },
@@ -267,7 +267,7 @@ export function archiveSession(sessionId, reason = 'manual') {
       .get(sessionId, STEP_TYPE.OFFSITE)
     if (off && (off.status === NODE_STATUS.RUNNING || off.status === NODE_STATUS.WAITING_HUMAN)) {
       const prev = parseJson(off.output_json, {})
-      engineBus.emit('update_node', off.id, {
+      engineEmit('update_node', off.id, {
         status: NODE_STATUS.PENDING,
         output_json: JSON.stringify({ ...prev, archivedIdle: true }),
         finished_at: t,
@@ -289,7 +289,7 @@ export function archiveSession(sessionId, reason = 'manual') {
   } catch {
     /* ignore */
   }
-  engineBus.emit('persist_session', sessionId, {
+  engineEmit('persist_session', sessionId, {
     status: SESSION_STATUS.ARCHIVED,
     archive_reason: reason,
     archived_at: t,
@@ -297,7 +297,7 @@ export function archiveSession(sessionId, reason = 'manual') {
   })
   if (killed.killed > 0) {
     try {
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         content: {
@@ -309,7 +309,7 @@ export function archiveSession(sessionId, reason = 'manual') {
     }
   } else {
     try {
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         content: {
@@ -320,11 +320,11 @@ export function archiveSession(sessionId, reason = 'manual') {
       /* ignore */
     }
   }
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.archived',
     payload: { sessionId, reason, processesKilled: killed.killed, pids: killed.pids },
   })
-  engineBus.emit('ws_broadcast_all', {
+  engineEmit('ws_broadcast_all', {
     type: 'session.archived',
     payload: { sessionId, reason, processesKilled: killed.killed },
   })
@@ -363,14 +363,14 @@ export function unarchiveSession(sessionId, { silent = false, reason = 'manual' 
     )
     .get(sessionId, NODE_STATUS.WAITING_HUMAN, STEP_TYPE.OFFSITE)
   const nextStatus = waiting ? SESSION_STATUS.WAITING_HUMAN : SESSION_STATUS.ACTIVE
-  engineBus.emit('persist_session', sessionId, {
+  engineEmit('persist_session', sessionId, {
     status: nextStatus,
     archive_reason: null,
     archived_at: null,
     context_json: JSON.stringify(ctx),
   })
   if (!silent) {
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: {
@@ -379,11 +379,11 @@ export function unarchiveSession(sessionId, { silent = false, reason = 'manual' 
       },
     })
   }
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.status',
     payload: { sessionId, status: nextStatus, unarchived: true },
   })
-  engineBus.emit('ws_broadcast_all', {
+  engineEmit('ws_broadcast_all', {
     type: 'session.status',
     payload: { sessionId, status: nextStatus, unarchived: true },
   })
@@ -411,7 +411,7 @@ export function markInterruptedOnBoot() {
       .all(s.id, NODE_STATUS.RUNNING)
     for (const n of running) {
       const prev = parseJson(n.output_json, {})
-      engineBus.emit('update_node', n.id, {
+      engineEmit('update_node', n.id, {
         status: NODE_STATUS.WAITING_HUMAN,
         output_json: JSON.stringify({
           ...prev,
@@ -428,18 +428,18 @@ export function markInterruptedOnBoot() {
       pendingResume: true,
       runningNodes: running.map((n) => n.id),
     }
-    engineBus.emit('persist_session', s.id, {
+    engineEmit('persist_session', s.id, {
       status: SESSION_STATUS.INTERRUPTED,
       context_json: JSON.stringify(ctx),
     })
-    engineBus.emit('add_message', s.id, {
+    engineEmit('add_message', s.id, {
       role: 'system',
       type: 'status',
       content: {
         text: '检测到服务重启或异常退出，本任务已暂停。请选择：继续 / 放弃。进程可在设置里释放。',
       },
     })
-    engineBus.emit('add_message', s.id, {
+    engineEmit('add_message', s.id, {
       role: 'system',
       type: 'gate',
       content: {
@@ -449,14 +449,14 @@ export function markInterruptedOnBoot() {
         policy: '不会自动推进；须人工选择。继续时若有未完成 running 节点会从该步重跑。释放进程请到设置。',
       },
     })
-    engineBus.emit('ws_broadcast_session', s.id, {
+    engineEmit('ws_broadcast_session', s.id, {
       type: 'session.interrupted',
       payload: { sessionId: s.id, previousStatus: s.status },
     })
     ids.push(s.id)
   }
   if (ids.length) {
-    engineBus.emit('ws_broadcast_all', { type: 'sessions.interrupted', payload: { ids } })
+    engineEmit('ws_broadcast_all', { type: 'sessions.interrupted', payload: { ids } })
     console.log(`[acw] interrupted ${ids.length} session(s) for recovery`)
   }
   // 已归档会话：清掉残留 console pid 文件，避免误报占用

--- a/server/src/engine/events.js
+++ b/server/src/engine/events.js
@@ -1,11 +1,27 @@
 import { EventEmitter } from 'node:events'
 
 /**
- * 引擎内部事件总线，负责解耦状态机流转与外部副作用（如 WS 广播）。
- * Phase 4.8.0 引入：使 engine/ 的核心逻辑不再直接引用 bus.js，便于后续完全解耦与测试注入。
+ * 引擎内部事件总线：解耦状态机与 WS / 持久化副作用。
+ * 必须通过 engineEmit 派发；无监听器时抛错，避免静默丢库。
  */
-export const engineBus = new EventEmitter()
+export const ENGINE_EVENTS = Object.freeze({
+  WS_BROADCAST_SESSION: 'ws_broadcast_session',
+  WS_BROADCAST_ALL: 'ws_broadcast_all',
+  UPDATE_NODE: 'update_node',
+  PERSIST_SESSION: 'persist_session',
+  PERSIST_NODE_IO: 'persist_node_io',
+  ADD_MESSAGE: 'add_message',
+  UPDATE_MESSAGE: 'update_message',
+})
 
-// 建议所有事件名都在此处登记，方便溯源
-// 'ws_broadcast_session': (sessionId, payload) => void
-// 'ws_broadcast_all': (payload) => void
+export const engineBus = new EventEmitter()
+engineBus.setMaxListeners(20)
+
+export function engineEmit(event, ...args) {
+  if (engineBus.listenerCount(event) === 0) {
+    const err = new Error(`[engineBus] no listener for "${event}"`)
+    err.code = 'ENGINE_BUS_NO_LISTENER'
+    throw err
+  }
+  return engineBus.emit(event, ...args)
+}

--- a/server/src/engine/gates.js
+++ b/server/src/engine/gates.js
@@ -1,7 +1,7 @@
 // 闸门动作：幂等、启动确认、归档确认、人工输入、同意/拒绝。
 // Imports: store, offsite, archive, adapterEvents, sessionLifecycle, advance.
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import {
   SESSION_STATUS,
   NODE_STATUS,
@@ -75,7 +75,7 @@ function rememberGateIdempotency(sessionId, key, result) {
       })
   }
   ctx.gateIdempotency = next
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
 }
 
 export async function handleGateAction(sessionId, { action, text, nodeInstanceId, idempotencyKey, questionId, choice }) {
@@ -190,15 +190,15 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       if (!pendingStart) throw new Error('当前没有待确认的启动')
       if (action === 'cancel_start' || action === 'reject') {
         delete ctxStart.pendingStart
-        engineBus.emit('persist_session', sessionId, {
+        engineEmit('persist_session', sessionId, {
           context_json: JSON.stringify(ctxStart),
         })
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'user',
           type: 'gate',
           content: { text: '已取消启动', action: 'cancel_start', mode: 'session_start' },
         })
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'system',
           type: 'status',
           content: { text: '未启动流程，任务已关闭' },
@@ -271,13 +271,13 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       }
 
       const autoTitleStart = syncAutoSessionTitle(ctxStart, getGroup(session.group_id))
-      engineBus.emit('persist_session', sessionId, {
+      engineEmit('persist_session', sessionId, {
         status: SESSION_STATUS.ACTIVE,
         context_json: JSON.stringify(ctxStart),
         ...(autoTitleStart ? { title: autoTitleStart } : {}),
       })
 
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'user',
         type: 'gate',
         content: {
@@ -288,7 +288,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
         },
       })
       if (parsed?.list?.length) {
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'system',
           type: 'status',
           content: {
@@ -298,7 +298,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
           },
         })
       } else if (inputText.trim() && callArgsOnly) {
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'system',
           type: 'status',
           content: {
@@ -307,7 +307,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
           },
         })
       } else {
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'system',
           type: 'status',
           content: { text: '已确认启动，开始执行流程…' },
@@ -320,7 +320,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       } catch (e) {
         console.warn('[acw] furnace situation kickoff', e?.message || e)
       }
-      engineBus.emit('ws_broadcast_session', sessionId, {
+      engineEmit('ws_broadcast_session', sessionId, {
         type: 'session.status',
         payload: { sessionId, status: SESSION_STATUS.ACTIVE, pendingStart: false },
       })
@@ -352,7 +352,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       if (!pending) throw new Error('当前没有待确认的归档')
       const archNote = text != null ? String(text).trim() : ''
       if (action === 'defer_archive' || action === 'reject') {
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'user',
           type: 'gate',
           content: {
@@ -371,9 +371,9 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
             actionLabel: '暂不归档',
             text: archNote,
           })
-          engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(c) })
+          engineEmit('persist_session', sessionId, { context_json: JSON.stringify(c) })
         }
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'system',
           type: 'status',
           content: {
@@ -385,7 +385,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
         refreshSessionAnnouncement(sessionId)
         return { deferred: true, pendingArchive: pending }
       }
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'user',
         type: 'gate',
         content: {
@@ -405,7 +405,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
           text: archNote,
         })
         c.lastHumanInput = archNote
-        engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(c) })
+        engineEmit('persist_session', sessionId, { context_json: JSON.stringify(c) })
       }
       refreshSessionAnnouncement(sessionId)
       const reason = pending.reason || 'manual'
@@ -507,13 +507,13 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
         },
       )
       const autoTitleNeed = syncAutoSessionTitle(ctx, group)
-      engineBus.emit('persist_session', sessionId, {
+      engineEmit('persist_session', sessionId, {
         context_json: JSON.stringify(ctx),
         status: SESSION_STATUS.ACTIVE,
         current_step_index: node.step_index,
         ...(autoTitleNeed ? { title: autoTitleNeed } : {}),
       })
-      engineBus.emit('persist_node_io', sessionId, node.id, {
+      engineEmit('persist_node_io', sessionId, node.id, {
         input: {
           ...prevIn,
           submitted: fullText,
@@ -527,13 +527,13 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
         },
         status: NODE_STATUS.PENDING,
       })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'user',
         type: 'text',
         node_instance_id: node.id,
         content: { text: fullText, params: parsed.map },
       })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         content: {
@@ -586,7 +586,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
     }
 
     const autoTitleHuman = syncAutoSessionTitle(ctx, group)
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       context_json: JSON.stringify(ctx),
       status: SESSION_STATUS.ACTIVE,
       ...(autoTitleHuman ? { title: autoTitleHuman } : {}),
@@ -602,7 +602,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       outPayload.paramsPreview = formatAddedParamsText(parsed.added, parsed.startIndex)
     }
 
-    engineBus.emit('persist_node_io', sessionId, node.id, {
+    engineEmit('persist_node_io', sessionId, node.id, {
       input: {
         ...prevIn,
         submitted: fullText || '',
@@ -612,14 +612,14 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       status: NODE_STATUS.SUCCEEDED,
       finished: true,
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'user',
       type: 'text',
       node_instance_id: node.id,
       content: { text: fullText || '(空)', params: parsed?.map || undefined },
     })
     if (parsed?.added?.length) {
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         content: {
@@ -631,7 +631,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
     }
     // 人工步结束：刷新群报告后继续（无 bat；成功/失败语义由后续节点决定）
     refreshSessionAnnouncement(sessionId)
-    engineBus.emit('persist_session', sessionId, { current_step_index: node.step_index + 1 })
+    engineEmit('persist_session', sessionId, { current_step_index: node.step_index + 1 })
     setImmediate(() => advance(sessionId).catch(console.error))
     return { ok: true, submitted: true }
   }
@@ -647,7 +647,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
         nodeTitle: node.title || `步骤 ${Number(node.step_index) + 1}`,
         nodeInstanceId: node.id,
       })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'user',
         type: 'gate',
         node_instance_id: node.id,
@@ -657,12 +657,12 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
           mode: 'path_busy',
         },
       })
-      engineBus.emit('update_node', node.id, {
+      engineEmit('update_node', node.id, {
         status: NODE_STATUS.PENDING,
         output_json: JSON.stringify({ retriedPathBusy: true }),
         finished_at: null,
       })
-      engineBus.emit('persist_session', sessionId, {
+      engineEmit('persist_session', sessionId, {
         status: SESSION_STATUS.ACTIVE,
         current_step_index: node.step_index,
       })
@@ -708,7 +708,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       : !!(votes.human || votes.admin)
 
     const baseLabel = action === 'admin_approve' ? `${FURNACE_DISPLAY_NAME}已同意` : '已同意'
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'user',
       type: 'gate',
       node_instance_id: node.id,
@@ -733,11 +733,11 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
     }
 
     if (!passed) {
-      engineBus.emit('update_node', node.id, {
+      engineEmit('update_node', node.id, {
         status: NODE_STATUS.WAITING_HUMAN,
         output_json: JSON.stringify(outWithNote),
       })
-      engineBus.emit('add_message', sessionId, {
+      engineEmit('add_message', sessionId, {
         role: 'system',
         type: 'status',
         content: {
@@ -750,14 +750,14 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       return { ok: true, passed: false }
     }
 
-    engineBus.emit('update_node', node.id, {
+    engineEmit('update_node', node.id, {
       status: NODE_STATUS.SUCCEEDED,
       finished_at: nowIso(),
       output_json: JSON.stringify({ ...outWithNote, passed: true }),
     })
     // 同意后刷新群报告（含附言与节点产出）
     refreshSessionAnnouncement(sessionId)
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       status: SESSION_STATUS.ACTIVE,
       current_step_index: node.step_index + 1,
     })
@@ -780,7 +780,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       nodeTitle: node.title || `步骤 ${Number(node.step_index) + 1}`,
       nodeInstanceId: node.id,
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'user',
       type: 'gate',
       node_instance_id: node.id,
@@ -791,7 +791,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
       },
     })
     // 明确拒绝 = 不通过（保留产出 + 附言）
-    engineBus.emit('update_node', node.id, {
+    engineEmit('update_node', node.id, {
       status: NODE_STATUS.FAILED,
       finished_at: nowIso(),
       output_json: JSON.stringify({
@@ -802,7 +802,7 @@ async function handleGateActionCore(sessionId, { action, text, nodeInstanceId, q
         rejected: true,
       }),
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: { text: note ? `明确拒绝：${note}` : '明确拒绝，节点不通过' },

--- a/server/src/engine/listeners.js
+++ b/server/src/engine/listeners.js
@@ -1,0 +1,45 @@
+// 副作用监听：持久化与 WS 广播。由 engine.js 门面加载；重复 import 不会重复挂接。
+import { engineBus, ENGINE_EVENTS } from './events.js'
+import { emitSession, emitAll } from '../bus.js'
+import {
+  updateSession,
+  persistNodeIo,
+  addMessage,
+  updateMessageContent,
+  updateNode,
+} from './store.js'
+
+let attached = false
+
+export function attachEngineListeners() {
+  if (attached) return
+  attached = true
+
+  engineBus.on(ENGINE_EVENTS.WS_BROADCAST_SESSION, (sessionId, payload) => {
+    emitSession(sessionId, payload)
+  })
+  engineBus.on(ENGINE_EVENTS.WS_BROADCAST_ALL, (payload) => {
+    emitAll(payload)
+  })
+  engineBus.on(ENGINE_EVENTS.UPDATE_NODE, (nodeId, patch) => {
+    updateNode(nodeId, patch)
+  })
+  engineBus.on(ENGINE_EVENTS.PERSIST_SESSION, (sessionId, patch) => {
+    updateSession(sessionId, patch)
+  })
+  engineBus.on(ENGINE_EVENTS.PERSIST_NODE_IO, (sessionId, nodeId, ioData) => {
+    persistNodeIo(sessionId, nodeId, ioData)
+  })
+  engineBus.on(ENGINE_EVENTS.ADD_MESSAGE, (sessionId, msg) => {
+    addMessage(sessionId, msg)
+  })
+  engineBus.on(ENGINE_EVENTS.UPDATE_MESSAGE, (messageId, content) => {
+    updateMessageContent(messageId, content)
+  })
+}
+
+export function engineListenersAttached() {
+  return attached
+}
+
+attachEngineListeners()

--- a/server/src/engine/mentions.js
+++ b/server/src/engine/mentions.js
@@ -1,7 +1,7 @@
 // @成员 临时协助：提及解析、串行执行队列、场外节点结果落地。
 // Imports: store, offsite.
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import { runMember } from '../runners.js'
 import {
   SESSION_STATUS,
@@ -103,16 +103,16 @@ async function runMentionedMembers(sessionId, text) {
     planned: mode === OFFSITE_MODE.PLANNED,
     mentionText: String(text || '').slice(0, 500),
   }
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
 
   const prevOut = parseJson(offsite.output_json, {})
   const history = Array.isArray(prevOut.assists) ? prevOut.assists : []
-  engineBus.emit('update_node', offsite.id, {
+  engineEmit('update_node', offsite.id, {
     status: NODE_STATUS.RUNNING,
     started_at: startedAt,
     finished_at: null,
   })
-  engineBus.emit('persist_node_io', sessionId, offsite.id, {
+  engineEmit('persist_node_io', sessionId, offsite.id, {
     input: {
       kind: 'offsite',
       text: String(text || ''),
@@ -132,7 +132,7 @@ async function runMentionedMembers(sessionId, text) {
     status: NODE_STATUS.RUNNING,
   })
 
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'status',
     node_instance_id: offsite.id,
@@ -152,7 +152,7 @@ async function runMentionedMembers(sessionId, text) {
       offsite = ensureOffsiteNode(sessionId, { expand: true })
     }
 
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'member',
       member_id: member.id,
       type: 'text',
@@ -194,7 +194,7 @@ async function runMentionedMembers(sessionId, text) {
       offsite = ensureOffsiteNode(sessionId, { expand: true })
     }
 
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'member',
       member_id: member.id,
       type: 'text',
@@ -241,7 +241,7 @@ async function runMentionedMembers(sessionId, text) {
 
   if (startArchived) {
     // 回主线后的异步收尾 = 新场外段落，写完即归档（线性扩展）
-    engineBus.emit('persist_node_io', sessionId, offsite.id, {
+    engineEmit('persist_node_io', sessionId, offsite.id, {
       input: {
         kind: 'offsite',
         text: String(text || ''),
@@ -263,7 +263,7 @@ async function runMentionedMembers(sessionId, text) {
       status: NODE_STATUS.SUCCEEDED,
       finished: true,
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       node_instance_id: offsite.id,
@@ -277,7 +277,7 @@ async function runMentionedMembers(sessionId, text) {
     return { invoked, offsiteNodeId: offsite.id, offsiteMode: mode, lateExpand: true }
   }
 
-  engineBus.emit('persist_node_io', sessionId, offsite.id, {
+  engineEmit('persist_node_io', sessionId, offsite.id, {
     input: parseJson(cur?.input_json, {}),
     output: {
       ...curOut,
@@ -299,8 +299,8 @@ async function runMentionedMembers(sessionId, text) {
     mode,
     planned: mode === OFFSITE_MODE.PLANNED,
   }
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctxLive) })
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctxLive) })
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.status',
     payload: {
       sessionId,

--- a/server/src/engine/offsite.js
+++ b/server/src/engine/offsite.js
@@ -1,7 +1,7 @@
 // 场外协助（@成员 插队）节点：插入、复用、回归主线归档。
 // Imports: store only (below archive/advance/gates in the engine DAG).
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import {
   NODE_STATUS,
   OFFSITE_MODE,
@@ -10,7 +10,7 @@ import {
   nowIso,
   uid,
 } from '@acw/shared'
-import { getSession, updateSession, addMessage, persistNodeIo } from './store.js'
+import { getSession, updateSession } from './store.js'
 
 /**
  * 场外插入游标：当前主线步索引（开场未跑则为 0 → 插到最前）。
@@ -64,6 +64,7 @@ function insertOffsiteAtCursor(sessionId, { title } = {}) {
     const session = getSession(sessionId)
     const cur = Number(session?.current_step_index)
     if (Number.isFinite(cur) && cur >= insertIdx) {
+      // 事务内必须直写：engineEmit 出事务后才会落到别的连接语义上，这里要同一 BEGIN
       updateSession(sessionId, { current_step_index: cur + 1 })
     }
   })
@@ -215,7 +216,7 @@ export function archiveOffsiteOnReturnToMain(sessionId, {
     if (!hung && !pinned) continue
 
     const prev = parseJson(n.output_json, {})
-    persistNodeIo(sessionId, n.id, {
+    engineEmit('persist_node_io', sessionId, n.id, {
       input: parseJson(n.input_json, {}),
       output: {
         ...prev,
@@ -246,11 +247,11 @@ export function archiveOffsiteOnReturnToMain(sessionId, {
     resumeTitle,
     resumeNodeId,
   }
-  updateSession(sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
 
   if (!silent && (closed.length || hadActive)) {
     const where = resumeTitle ? `「${resumeTitle}」` : '主线节点'
-    addMessage(sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: {
@@ -263,7 +264,7 @@ export function archiveOffsiteOnReturnToMain(sessionId, {
     })
   }
 
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.status',
     payload: {
       sessionId,
@@ -299,7 +300,7 @@ export function appendOffsiteNodeChat(sessionId, nodeId, text) {
   const prevOut = parseJson(node.output_json, {})
   const prevHuman = String(prevIn.humanInput || '').trim()
   const humanInput = prevHuman ? `${prevHuman}\n${note}` : note
-  persistNodeIo(sessionId, nodeId, {
+  engineEmit('persist_node_io', sessionId, nodeId, {
     input: {
       ...prevIn,
       kind: 'offsite',

--- a/server/src/engine/sessionLifecycle.js
+++ b/server/src/engine/sessionLifecycle.js
@@ -1,7 +1,7 @@
 // 会话生命周期：创建（群聊 / 成员单聊）、克隆续跑、中断恢复。
 // Imports: store, offsite, archive, advance (gates sits above).
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import { killSessionProcesses } from '../processRegistry.js'
 import {
   SESSION_STATUS,
@@ -137,13 +137,13 @@ export function createSessionFromGroup(groupId, { title } = {}) {
   // 不再挂归档尾节点：释放资源改到设置里手动操作
 
   if (isAdhoc) {
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: { text: `已与「${group.title}」开聊。发消息继续；@ 其他成员可临时协助。` },
     })
-    engineBus.emit('ws_broadcast_all', { type: 'session.created', payload: { sessionId, groupId } })
-    engineBus.emit('ws_broadcast_session', sessionId, {
+    engineEmit('ws_broadcast_all', { type: 'session.created', payload: { sessionId, groupId } })
+    engineEmit('ws_broadcast_session', sessionId, {
       type: 'session.status',
       payload: { sessionId, status: SESSION_STATUS.ACTIVE, pendingStart: false },
     })
@@ -158,12 +158,12 @@ export function createSessionFromGroup(groupId, { title } = {}) {
     return getSession(sessionId)
   }
 
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'status',
     content: { text: `任务已创建，使用模板「${group.title}」。请确认后开始。` },
   })
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'gate',
     node_instance_id: null,
@@ -181,12 +181,12 @@ export function createSessionFromGroup(groupId, { title } = {}) {
     },
   })
 
-  engineBus.emit('ws_broadcast_all', { type: 'session.created', payload: { sessionId, groupId } })
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_all', { type: 'session.created', payload: { sessionId, groupId } })
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'gate.request',
     payload: { mode: 'session_start', sessionId, groupTitle: group.title },
   })
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.status',
     payload: { sessionId, status: SESSION_STATUS.WAITING_HUMAN, pendingStart: true },
   })
@@ -229,7 +229,7 @@ function resumeAdhocIfStillPendingStart(sessionId) {
   delete ctx.pendingStart
   const nextStatus =
     session.status === SESSION_STATUS.ARCHIVED ? SESSION_STATUS.ACTIVE : SESSION_STATUS.ACTIVE
-  engineBus.emit('persist_session', sessionId, {
+  engineEmit('persist_session', sessionId, {
     status: nextStatus,
     context_json: JSON.stringify(ctx),
   })
@@ -320,7 +320,7 @@ export function bypassAbandonedNodes(sessionId, { keepNodeIds = [], beforeStepIn
       node.status === NODE_STATUS.PENDING
     if (!abandon) continue
     const prevOut = parseJson(node.output_json, {})
-    engineBus.emit('update_node', node.id, {
+    engineEmit('update_node', node.id, {
       status: NODE_STATUS.SKIPPED,
       finished_at: at,
       output_json: JSON.stringify({
@@ -468,7 +468,7 @@ export async function restartFromNode(sessionId, opts = {}) {
 
   const ctx = parseJson(session.context_json, {})
   delete ctx.pendingArchive
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
 
   const targetDone =
     target.status === NODE_STATUS.SUCCEEDED || target.status === NODE_STATUS.SKIPPED
@@ -488,7 +488,7 @@ export async function restartFromNode(sessionId, opts = {}) {
     // 仅把「执行中」收回待跑以便重入；已在待确认的保留闸门，勿清空产出重跑
     if (target.status === NODE_STATUS.RUNNING) {
       const prevOut = parseJson(target.output_json, {})
-      engineBus.emit('update_node', target.id, {
+      engineEmit('update_node', target.id, {
         status: NODE_STATUS.PENDING,
         finished_at: null,
         started_at: null,
@@ -521,14 +521,14 @@ export async function restartFromNode(sessionId, opts = {}) {
       sourceNodeInstanceId: target.id,
       sourceStepIndex: idx,
     }
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       status: SESSION_STATUS.ACTIVE,
       current_step_index: idx,
       context_json: JSON.stringify(ctx2),
       archive_reason: null,
       archived_at: null,
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: {
@@ -543,7 +543,7 @@ export async function restartFromNode(sessionId, opts = {}) {
         },
       },
     })
-    engineBus.emit('ws_broadcast_session', sessionId, {
+    engineEmit('ws_broadcast_session', sessionId, {
       type: 'session.restart',
       payload: {
         sessionId,
@@ -554,7 +554,7 @@ export async function restartFromNode(sessionId, opts = {}) {
         forwardJump: true,
       },
     })
-    engineBus.emit('ws_broadcast_session', sessionId, {
+    engineEmit('ws_broadcast_session', sessionId, {
       type: 'session.status',
       payload: {
         sessionId,
@@ -564,7 +564,7 @@ export async function restartFromNode(sessionId, opts = {}) {
         forwardJump: true,
       },
     })
-    engineBus.emit('ws_broadcast_all', {
+    engineEmit('ws_broadcast_all', {
       type: 'session.restart',
       payload: { sessionId, stepIndex: idx, cloned: false, forwardJump: true },
     })
@@ -620,7 +620,7 @@ export async function restartFromNode(sessionId, opts = {}) {
     sourceStepIndex: idx,
   }
 
-  engineBus.emit('persist_session', sessionId, {
+  engineEmit('persist_session', sessionId, {
     status: SESSION_STATUS.ACTIVE,
     current_step_index: startIdx,
     context_json: JSON.stringify(ctx2),
@@ -628,7 +628,7 @@ export async function restartFromNode(sessionId, opts = {}) {
     archived_at: null,
   })
 
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'status',
     content: {
@@ -645,7 +645,7 @@ export async function restartFromNode(sessionId, opts = {}) {
     },
   })
 
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.restart',
     payload: {
       sessionId,
@@ -657,7 +657,7 @@ export async function restartFromNode(sessionId, opts = {}) {
       sourceNodeInstanceId: target.id,
     },
   })
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'session.status',
     payload: {
       sessionId,
@@ -666,7 +666,7 @@ export async function restartFromNode(sessionId, opts = {}) {
       cloned: true,
     },
   })
-  engineBus.emit('ws_broadcast_all', {
+  engineEmit('ws_broadcast_all', {
     type: 'session.restart',
     payload: { sessionId, stepIndex: startIdx, cloned: true },
   })
@@ -704,7 +704,7 @@ export async function resolveInterruptedSession(sessionId, action) {
     .replace(/^discard_interrupted$/, 'discard')
 
   if (act === 'archive' || act === 'discard') {
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'user',
       type: 'gate',
       content: {
@@ -727,7 +727,7 @@ export async function resolveInterruptedSession(sessionId, action) {
         n.status === NODE_STATUS.RUNNING ||
         n.status === NODE_STATUS.WAITING_HUMAN
       ) {
-        engineBus.emit('persist_node_io', sessionId, n.id, {
+        engineEmit('persist_node_io', sessionId, n.id, {
           input: parseJson(n.input_json, {}),
           output: {
             ...parseJson(n.output_json, {}),
@@ -747,11 +747,11 @@ export async function resolveInterruptedSession(sessionId, action) {
       resolution: 'discard',
     }
     delete ctx.pendingArchive
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       status: SESSION_STATUS.FAILED,
       context_json: JSON.stringify(ctx),
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: {
@@ -774,7 +774,7 @@ export async function resolveInterruptedSession(sessionId, action) {
     resolution: 'resume',
   }
 
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'user',
     type: 'gate',
     content: {
@@ -790,7 +790,7 @@ export async function resolveInterruptedSession(sessionId, action) {
     .all(sessionId)
   const interruptedNode = nodes.find((n) => parseJson(n.output_json, {})?.interrupted === true)
   if (interruptedNode) {
-    engineBus.emit('update_node', interruptedNode.id, {
+    engineEmit('update_node', interruptedNode.id, {
       status: NODE_STATUS.PENDING,
       output_json: JSON.stringify({
         ...parseJson(interruptedNode.output_json, {}),
@@ -800,12 +800,12 @@ export async function resolveInterruptedSession(sessionId, action) {
       finished_at: null,
     })
     // 该步之后若曾误推进，保持其后 pending
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       status: SESSION_STATUS.ACTIVE,
       current_step_index: interruptedNode.step_index,
       context_json: JSON.stringify(ctx),
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: { text: `从中断节点「${interruptedNode.title}」继续执行…` },
@@ -815,11 +815,11 @@ export async function resolveInterruptedSession(sessionId, action) {
   }
 
   if (ctx.pendingStart) {
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       status: SESSION_STATUS.WAITING_HUMAN,
       context_json: JSON.stringify(ctx),
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: { text: '已恢复到开聊确认，请继续操作。' },
@@ -833,11 +833,11 @@ export async function resolveInterruptedSession(sessionId, action) {
 
   const waiting = nodes.find((n) => n.status === NODE_STATUS.WAITING_HUMAN)
   if (waiting || prevStatus === SESSION_STATUS.WAITING_HUMAN) {
-    engineBus.emit('persist_session', sessionId, {
+    engineEmit('persist_session', sessionId, {
       status: SESSION_STATUS.WAITING_HUMAN,
       context_json: JSON.stringify(ctx),
     })
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'system',
       type: 'status',
       content: { text: '已恢复到待确认，请继续操作。' },
@@ -845,11 +845,11 @@ export async function resolveInterruptedSession(sessionId, action) {
     return { ok: true, resumed: true, waitingHuman: true }
   }
 
-  engineBus.emit('persist_session', sessionId, {
+  engineEmit('persist_session', sessionId, {
     status: SESSION_STATUS.ACTIVE,
     context_json: JSON.stringify(ctx),
   })
-  engineBus.emit('add_message', sessionId, {
+  engineEmit('add_message', sessionId, {
     role: 'system',
     type: 'status',
     content: { text: '已恢复，继续推进流程…' },

--- a/server/src/engine/store.js
+++ b/server/src/engine/store.js
@@ -1,7 +1,8 @@
 // Engine primitives: DB row access, session/node/message writes, ctx helpers.
-// Lowest engine layer — imported by every other engine module; imports nothing from engine/.
+// Lowest engine layer — imported by every other engine module.
 import { getDb, parseJson } from '../db.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
+import './listeners.js'
 import { writeNodeJournal } from '../journal.js'
 import {
   SYSTEM_PARAM_KEYS,
@@ -109,7 +110,7 @@ export function bindGateHumanInput(sessionId, {
       nodeInstanceId,
     })
   }
-  engineBus.emit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
+  engineEmit('persist_session', sessionId, { context_json: JSON.stringify(ctx) })
   return { full, note }
 }
 
@@ -167,7 +168,7 @@ export function addMessage(sessionId, msg) {
     )
     .run(row)
   const out = { ...row, content: msg.content ?? {} }
-  engineBus.emit('ws_broadcast_session', sessionId, { type: 'message', payload: out })
+  engineEmit('ws_broadcast_session', sessionId, { type: 'message', payload: out })
   return out
 }
 
@@ -178,7 +179,7 @@ export function updateMessageContent(id, content) {
     .prepare('UPDATE messages SET content_json = ? WHERE id = ?')
     .run(JSON.stringify(content ?? {}), id)
   const next = { ...row, content: content ?? {}, content_json: JSON.stringify(content ?? {}) }
-  engineBus.emit('ws_broadcast_session', row.session_id, { type: 'message', payload: next })
+  engineEmit('ws_broadcast_session', row.session_id, { type: 'message', payload: next })
   return next
 }
 
@@ -201,7 +202,7 @@ export function updateNode(id, patch) {
       id,
     )
   const sessionId = n.session_id
-  engineBus.emit('ws_broadcast_session', sessionId, {
+  engineEmit('ws_broadcast_session', sessionId, {
     type: 'node.status',
     payload: {
       nodeInstanceId: id,

--- a/server/src/engine/userInput.js
+++ b/server/src/engine/userInput.js
@@ -14,7 +14,7 @@ import {
   isMentionAssistOnly,
 } from '@acw/shared'
 import { getSession, getGroup, getMember, syncAutoSessionTitle,  } from './store.js'
-import { engineBus } from './events.js'
+import { engineEmit } from './events.js'
 import { ensureOffsiteNode, resolveOffsiteMode, appendOffsiteNodeChat } from './offsite.js'
 import { unarchiveSession, refreshSessionAnnouncement } from './archive.js'
 import { syncFurnaceSessionContext } from '../furnaceSituation.js'
@@ -85,7 +85,7 @@ export function recordUserChatInput(
     nodeInstanceId: nodeInstanceId || undefined,
   })
   const autoTitle = syncAutoSessionTitle(ctx, group)
-  engineBus.emit('persist_session', sessionId, {
+  engineEmit('persist_session', sessionId, {
     context_json: JSON.stringify(ctx),
     ...(autoTitle ? { title: autoTitle } : {}),
   })
@@ -108,7 +108,7 @@ function appendPendingGateNote(sessionId, node, text) {
   const action = prev.humanAction === 'approve' || prev.humanAction === 'reject'
     ? prev.humanAction
     : 'pending'
-  engineBus.emit('update_node', node.id, {
+  engineEmit('update_node', node.id, {
     status: NODE_STATUS.WAITING_HUMAN,
     output_json: JSON.stringify({
       ...prev,
@@ -183,7 +183,7 @@ export async function postUserMessage(sessionId, text, attachments = []) {
         nodeInstanceId: node.id,
       })
       if (atts.length) {
-        engineBus.emit('add_message', sessionId, {
+        engineEmit('add_message', sessionId, {
           role: 'user',
           type: 'text',
           content,
@@ -216,7 +216,7 @@ export async function postUserMessage(sessionId, text, attachments = []) {
           (parseJson(node.output_json, {}).needParams ||
             parseJson(node.output_json, {}).reason === 'missing_param_1')))
     )
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'user',
       type: 'text',
       node_instance_id: offsiteNode?.id || null,
@@ -258,7 +258,7 @@ export async function postUserMessage(sessionId, text, attachments = []) {
       ? ensureOffsiteNode(sessionId, { expand: true })
       : null
     const offsiteMode = offsiteNode ? resolveOffsiteMode(live, offsiteNode) : null
-    engineBus.emit('add_message', sessionId, {
+    engineEmit('add_message', sessionId, {
       role: 'user',
       type: 'text',
       node_instance_id: offsiteNode?.id || null,

--- a/server/src/processRegistry.js
+++ b/server/src/processRegistry.js
@@ -5,10 +5,17 @@
 import { spawn, execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { DATA_ROOT } from './db.js'
 
-let injectedDataRoot = process.cwd()
+/** 可选覆盖；未调用时与 db.DATA_ROOT（含 ACW_DATA_ROOT）一致，禁止回退到 cwd */
+let injectedDataRoot = null
+
 export function setRegistryContext(ctx) {
   if (ctx && ctx.DATA_ROOT) injectedDataRoot = ctx.DATA_ROOT
+}
+
+export function resolveRegistryDataRoot() {
+  return injectedDataRoot || DATA_ROOT
 }
 
 
@@ -30,18 +37,18 @@ function ensureSession(sessionId) {
 }
 
 function sessionPidFile(sessionId) {
-  return path.join(injectedDataRoot, 'console', `session_${sessionId}.pids`)
+  return path.join(resolveRegistryDataRoot(), 'console', `session_${sessionId}.pids`)
 }
 
 function runPidFile(sessionId, runId) {
-  return path.join(injectedDataRoot, 'console', `run_${sessionId}_${runId}.pid`)
+  return path.join(resolveRegistryDataRoot(), 'console', `run_${sessionId}_${runId}.pid`)
 }
 
 /** 会话级持久化 PID，避免仅内存表、或 Start-Process 子进程漏登 */
 export function rememberSessionPid(sessionId, pid, tag = '') {
   if (!sessionId || !pid || pid <= 0) return
   try {
-    const dir = path.join(injectedDataRoot, 'console')
+    const dir = path.join(resolveRegistryDataRoot(), 'console')
     fs.mkdirSync(dir, { recursive: true })
     const line = `${pid}${tag ? `\t${tag}` : ''}\n`
     fs.appendFileSync(sessionPidFile(sessionId), line, 'utf8')
@@ -166,7 +173,7 @@ export function cleanupArchivedSessionPidFiles(sessionIds) {
   for (const id of ids) {
     try {
       clearSessionPidFile(id)
-      const dir = path.join(injectedDataRoot, 'console')
+      const dir = path.join(resolveRegistryDataRoot(), 'console')
       if (!fs.existsSync(dir)) continue
       for (const name of fs.readdirSync(dir)) {
         if (name.startsWith(`run_${id}_`) && name.endsWith('.pid')) {
@@ -339,7 +346,7 @@ export function killSessionProcesses(sessionId, opts = {}) {
   }
   if (preservePids.size > 0) {
     try {
-      const dir = path.join(injectedDataRoot, 'console')
+      const dir = path.join(resolveRegistryDataRoot(), 'console')
       fs.mkdirSync(dir, { recursive: true })
       const lines = [...preservePids].map((p) => `${p}\tdetach\n`).join('')
       fs.writeFileSync(sessionPidFile(sessionId), lines, 'utf8')
@@ -352,7 +359,7 @@ export function killSessionProcesses(sessionId, opts = {}) {
 
   // 清理该会话残留 run_*.pid（detach 的 target 文件保留，供真正归档杀）
   try {
-    const dir = path.join(injectedDataRoot, 'console')
+    const dir = path.join(resolveRegistryDataRoot(), 'console')
     if (fs.existsSync(dir)) {
       for (const name of fs.readdirSync(dir)) {
         if (name.startsWith(`run_${sessionId}_`) && name.endsWith('.pid')) {
@@ -386,7 +393,7 @@ export function killSessionProcesses(sessionId, opts = {}) {
 export function writeRunTargetPid(sessionId, runId, pid) {
   if (!sessionId || !runId || !pid) return
   try {
-    const dir = path.join(injectedDataRoot, 'console')
+    const dir = path.join(resolveRegistryDataRoot(), 'console')
     fs.mkdirSync(dir, { recursive: true })
     fs.writeFileSync(runPidFile(sessionId, runId), String(pid), 'utf8')
     rememberSessionPid(sessionId, pid, 'target')
@@ -406,7 +413,7 @@ export function getRunPidFilePath(sessionId, runId) {
  */
 export function launchArchiveControlWindow({ sessionId, runId, title, apiBase }) {
   if (process.platform !== 'win32') return null
-  const dir = path.join(injectedDataRoot, 'console')
+  const dir = path.join(resolveRegistryDataRoot(), 'console')
   fs.mkdirSync(dir, { recursive: true })
   const file = path.join(dir, `ctl_${sessionId}_${runId}.hta`)
   const base = (

--- a/server/src/runners.js
+++ b/server/src/runners.js
@@ -601,7 +601,7 @@ export async function runMember(
     }
 
     return runProcess({
-      context: { DATA_ROOT: typeof DATA_ROOT !== 'undefined' ? DATA_ROOT : (global.DATA_ROOT || process.env.DATA_ROOT || process.cwd()) },
+      context: { DATA_ROOT },
       launch,
       cwd,
       env,
@@ -735,7 +735,7 @@ function runProcess({ context,
     const chunks = []
     const errChunks = []
     const runId = uid('run')
-    const captureLog = path.join(context?.DATA_ROOT || process.cwd(), 'logs', `run_${runId}.console.log`)
+    const captureLog = path.join(context?.DATA_ROOT || DATA_ROOT, 'logs', `run_${runId}.console.log`)
     const displayLabel = label || filePath || command || 'script'
     const targetPidFile =
       sessionId && showConsole && isWin ? getRunPidFilePath(sessionId, runId) : null
@@ -931,7 +931,7 @@ function runProcess({ context,
       const logName = `run_${Date.now()}.log`
       try {
         fs.writeFileSync(
-          path.join(context?.DATA_ROOT || process.cwd(), 'logs', logName),
+          path.join(context?.DATA_ROOT || DATA_ROOT, 'logs', logName),
           `cwd=${cwd}\npid=${pid}\ncode=${code}\ndetach=${!!detach}\nruntime=${launch.label}\nlabel=${displayLabel}\ncmd=${launch.cmd} ${(launch.args || []).join(' ')}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}\n`,
         )
       } catch {

--- a/server/test/engineBus.test.js
+++ b/server/test/engineBus.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+const { engineEmit } = await import('../src/engine/events.js')
+
+test('engineEmit throws when the event has no listener', () => {
+  assert.throws(
+    () => engineEmit('__missing_engine_event__', 1),
+    (err) => err?.code === 'ENGINE_BUS_NO_LISTENER',
+  )
+})
+
+test('engine facade attaches persist listeners', async () => {
+  await import('../src/engine.js')
+  const { engineListenersAttached } = await import('../src/engine/listeners.js')
+  assert.equal(engineListenersAttached(), true)
+})

--- a/server/test/processRegistry.test.js
+++ b/server/test/processRegistry.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const { DATA_ROOT } = await import('../src/db.js')
+const { rememberSessionPid, resolveRegistryDataRoot } = await import('../src/processRegistry.js')
+
+test('processRegistry defaults to db DATA_ROOT instead of process.cwd', () => {
+  assert.equal(resolveRegistryDataRoot(), DATA_ROOT)
+  const sessionId = `ses_reg_${Date.now()}`
+  rememberSessionPid(sessionId, 424242, 'test')
+  const pidFile = path.join(DATA_ROOT, 'console', `session_${sessionId}.pids`)
+  assert.equal(fs.existsSync(pidFile), true)
+  const cwdLeak = path.join(process.cwd(), 'console', `session_${sessionId}.pids`)
+  if (path.resolve(DATA_ROOT) !== path.resolve(process.cwd())) {
+    assert.equal(fs.existsSync(cwdLeak), false)
+  }
+  const text = fs.readFileSync(pidFile, 'utf8')
+  assert.match(text, /424242/)
+})

--- a/web/src/composables/useAppInit.js
+++ b/web/src/composables/useAppInit.js
@@ -1,6 +1,7 @@
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, h, onMounted, onUnmounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { api } from '../api'
+import router from '../router'
 import {
   setGrokConfigured,
   setFurnaceGrokGate,
@@ -50,16 +51,36 @@ export function useAppInit() {
     }
   }
 
-  // 4.7.0 启动时检查更新（静默，仅发现新版本时轻提示）
-  async function startupCheckUpdate() {
+  // 4.7.0 启动时检查更新（静默，仅发现新版本时轻提示；可点进关于页）
+  async function startupCheckUpdate(settings) {
     try {
-      const s = await api.appSettings.get()
-      if (s.updateCheck?.startup === false) return
+      const s = settings && typeof settings === 'object' ? settings : await api.appSettings.get()
+      if (!s || s.updateCheck?.startup === false) return
       const r = await api.update.check()
       if (!r.checked || !r.hasUpdate) return
-      ElMessage.info({
-        message: `发现新版本 v${r.latest}，前往设置 → 关于查看详情`,
+      const rawNotes = String(r.notes || '').replace(/\s+/g, ' ').trim()
+      const notesPreview = rawNotes.slice(0, 80)
+      ElMessage({
+        type: 'info',
         duration: 8000,
+        showClose: true,
+        message: h('span', { style: 'line-height:1.45' }, [
+          `发现新版本 v${r.latest}`,
+          notesPreview ? `：${notesPreview}${rawNotes.length > 80 ? '…' : ''}` : '',
+          ' · ',
+          h(
+            'button',
+            {
+              type: 'button',
+              style:
+                'padding:0;border:0;background:none;color:#409eff;cursor:pointer;text-decoration:underline;font:inherit',
+              onClick: () => {
+                router.push('/settings/about')
+              },
+            },
+            '前往关于查看详情',
+          ),
+        ]),
       })
     } catch {
       // 静默失败，不打扰用户
@@ -69,8 +90,7 @@ export function useAppInit() {
   onMounted(() => {
     document.addEventListener('fullscreenchange', syncFullscreenState)
     syncFullscreenState()
-    refreshGrokGate()
-    startupCheckUpdate()
+    refreshGrokGate().then(({ s }) => startupCheckUpdate(s))
   })
 
   onUnmounted(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
针对 4.7/4.8 代码审查中的高优先级问题：

- **进程登记**：`processRegistry` 未注入时跟随 `db.DATA_ROOT`（`ACW_DATA_ROOT`），不再默认写到 `process.cwd()`；脚本日志同样不再回退 cwd。
- **引擎总线**：`engineEmit` 在无监听器时抛 `ENGINE_BUS_NO_LISTENER`；监听器抽到 `listeners.js` 并防止重复挂接。
- **场外协助**：事务内仍直写 `updateSession`，其余走事件总线。
- **启动更新**：复用 Grok 探测已拉取的设置，轻提示带 changelog 摘录和「前往关于」按钮。

补充 `processRegistry` / `engineBus` 测试。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7aaa605-24fc-41f7-aa83-a94241aa1f14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7aaa605-24fc-41f7-aa83-a94241aa1f14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

