### PR TITLE
fix: Windows 双击 start.bat 没有窗口

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,10 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-09-11 | M | start.bat | cd 改用 %~dp0. 避免路径末尾反斜杠吃掉引号
+2026-09-11 | A | scripts/windowsStartBat.mjs electron/lib/splash.mjs electron/test/start-bat.test.mjs | 修复 start.bat 引号被 %~dp0 反斜杠吃掉导致窗口一闪就没；启动先出 splash 再等健康检查
+2026-09-11 | M | electron/main.js scripts/pack-release.mjs scripts/verify-pack.mjs README.md | 桌面包打包 splash.mjs；README 说明需换新 desktop.zip
+
 2026-09-11 | A | docs/assets/screenshots/windows-desktop.png | Windows 桌面窗口工作台截图
 2026-09-11 | M | README.md | 单独写清 Windows 桌面包（Release desktop.zip）与轻量运行包
 2026-09-11 | M | scripts/pack-release.mjs | 桌面包 --desktop 不进 git（超 100MB）；轻量 zip 仍入库

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@
 
 下载 [latest release](https://github.com/371684029/oh-my-co-work/releases/tag/latest) 里的 **`oh-my-co-work-v4-win32-x64-desktop.zip`**（内含 Electron 窗口和 Node 运行时，一般不用再装 Node.js）。
 
-解压后双击 `start.bat`。关窗会藏到托盘；要停服务请用托盘菜单 **退出**。
+解压后双击 `start.bat`，应立刻出现窗口（先显示「正在启动本机服务」，再进入工作台）。关窗会藏到托盘；要停服务请用托盘菜单 **退出**。
+
+若黑窗一闪什么都没有：请重新下载 **desktop.zip**（旧包里的 `start.bat` 会被路径末尾反斜杠吃掉引号，启动失败）。仍不行时看解压目录里的 `data/desktop-launch.log` 和 `data/desktop-server.log`。
 
 <img src="./docs/assets/screenshots/windows-desktop.png" alt="Windows 桌面窗口：oh-my-co-work 工作台" width="100%" />
 <p align="center"><sub>4.7.0 桌面包：独立窗口打开工作台，自动拉起本机服务</sub></p>

--- a/electron/lib/splash.mjs
+++ b/electron/lib/splash.mjs
@@ -1,0 +1,30 @@
+export function splashHtml() {
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>oh-my-co-work</title>
+  <style>
+    html, body { height: 100%; margin: 0; }
+    body {
+      display: flex; align-items: center; justify-content: center;
+      font-family: "Segoe UI", "PingFang SC", sans-serif;
+      background: #f4f7fb; color: #303133;
+    }
+    .box { text-align: center; }
+    h1 { font-size: 22px; font-weight: 600; margin: 0 0 8px; }
+    p { margin: 0; color: #909399; }
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>oh-my-co-work</h1>
+    <p>正在启动本机服务，请稍候…</p>
+  </div>
+</body>
+</html>`
+}
+
+export function splashDataUrl() {
+  return 'data:text/html;charset=utf-8,' + encodeURIComponent(splashHtml())
+}

--- a/electron/main.js
+++ b/electron/main.js
@@ -13,6 +13,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { desktopUpdateResult, workbenchUrl } from './lib/urls.mjs'
+import { splashDataUrl } from './lib/splash.mjs'
 import {
   isServerUp,
   resolveNodeBin,
@@ -99,6 +100,7 @@ async function createMainWindow() {
     minHeight: 600,
     title: 'oh-my-co-work',
     icon: path.join(__dirname, 'icon.png'),
+    show: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -107,7 +109,7 @@ async function createMainWindow() {
     },
   })
 
-  await mainWindow.loadURL(appOrigin() + '/workbench')
+  await mainWindow.loadURL(splashDataUrl())
 
   mainWindow.on('close', (evt) => {
     if (!isQuitting && trayOk) {
@@ -119,6 +121,11 @@ async function createMainWindow() {
   mainWindow.on('closed', () => {
     mainWindow = null
   })
+}
+
+async function loadWorkbench() {
+  if (!mainWindow) return
+  await mainWindow.loadURL(appOrigin() + '/workbench')
 }
 
 function registerIpc() {
@@ -165,6 +172,11 @@ async function ensureServer() {
     entry,
     logStream,
   })
+  serverChild.on('error', (err) => {
+    if (!isQuitting) {
+      dialog.showErrorBox('oh-my-co-work', `无法启动后台服务：${err?.message || err}`)
+    }
+  })
   serverChild.on('exit', (code) => {
     if (!isQuitting && code) {
       dialog.showErrorBox('oh-my-co-work', `后台服务已退出（${code}）。可查看 data/desktop-server.log`)
@@ -185,9 +197,10 @@ if (!gotLock) {
     appRoot = resolveAppRoot()
     process.chdir(appRoot)
     try {
-      await ensureServer()
       createTray()
       await createMainWindow()
+      await ensureServer()
+      await loadWorkbench()
     } catch (e) {
       dialog.showErrorBox('oh-my-co-work 启动失败', String(e?.message || e))
       isQuitting = true

--- a/electron/test/start-bat.test.mjs
+++ b/electron/test/start-bat.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { windowsStartBat } from '../../scripts/windowsStartBat.mjs'
+import { splashDataUrl, splashHtml } from '../lib/splash.mjs'
+
+test('start.bat 不用 /D "%~dp0" 这种会被反斜杠吃掉引号的写法', () => {
+  const bat = windowsStartBat()
+  assert.equal(bat.includes('/D "%~dp0"'), false)
+  assert.equal(bat.includes('cd /d "%~dp0"'), false)
+  assert.equal(bat.includes('/D "%~dp0."'), true)
+  assert.equal(bat.includes('cd /d "%~dp0."'), true)
+  assert.equal(bat.includes('desktop\\electron.exe'), true)
+  assert.equal(bat.includes('"%~dp0desktop\\electron.exe"'), true)
+})
+
+test('splash 页立刻能显示启动中', () => {
+  assert.match(splashHtml(), /正在启动本机服务/)
+  assert.match(splashDataUrl(), /^data:text\/html/)
+})

--- a/scripts/pack-release.mjs
+++ b/scripts/pack-release.mjs
@@ -19,6 +19,7 @@ import https from 'node:https'
 import { execFileSync, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
+import { windowsStartBat } from './windowsStartBat.mjs'
 
 /** Windows 桌面包内嵌运行时（与 CI Node 20 ABI、win32 原生模块对齐） */
 const PACK_NODE_VERSION = '20.18.3'
@@ -186,36 +187,7 @@ function copyDir(src, dest) {
 }
 
 function writeStartBat(dest) {
-  fs.writeFileSync(
-    dest,
-    [
-      '@echo off',
-      'chcp 65001 >nul',
-      'cd /d "%~dp0"',
-      'if exist "desktop\\electron.exe" (',
-      '  start "" /D "%~dp0" "desktop\\electron.exe" "%~dp0."',
-      '  exit /b 0',
-      ')',
-      'if exist "runtime\\node.exe" (',
-      '  echo [acw] 正在启动 oh-my-co-work（运行包，无需 npm install）…',
-      '  "runtime\\node.exe" start.mjs',
-      '  if errorlevel 1 pause',
-      '  exit /b %errorlevel%',
-      ')',
-      'where node >nul 2>nul',
-      'if errorlevel 1 (',
-      '  echo [acw] 未检测到 Node.js，请先安装 Node.js 18+ ：https://nodejs.org',
-      '  pause',
-      '  exit /b 1',
-      ')',
-      'echo [acw] 正在启动 oh-my-co-work（运行包，无需 npm install）…',
-      'echo [acw] 提示：关闭本窗口即可结束服务（关浏览器不会停）',
-      'node start.mjs',
-      'if errorlevel 1 pause',
-      '',
-    ].join('\r\n'),
-    'utf8',
-  )
+  fs.writeFileSync(dest, windowsStartBat(), 'utf8')
 }
 
 function downloadHttps(url, dest) {
@@ -273,7 +245,7 @@ function copyElectronAppFiles(stage) {
   }
   const libDest = path.join(electronDest, 'lib')
   fs.mkdirSync(libDest, { recursive: true })
-  for (const name of ['urls.mjs', 'server.mjs']) {
+  for (const name of ['urls.mjs', 'server.mjs', 'splash.mjs']) {
     copyFile(path.join(ROOT, 'electron', 'lib', name), path.join(libDest, name))
   }
 }

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -159,6 +159,7 @@ export function verifyPackedZip({ zipPath, platformTag, expectedVersion }) {
       { re: /\/electron\/main\.js$/, label: 'electron/main.js' },
       { re: /\/electron\/preload\.js$/, label: 'electron/preload.js' },
       { re: /\/electron\/icon\.png$/, label: 'electron/icon.png' },
+      { re: /\/electron\/lib\/splash\.mjs$/, label: 'electron/lib/splash.mjs' },
       { re: /\/desktop\/electron\.exe$/, label: 'desktop/electron.exe' },
       { re: /\/runtime\/node\.exe$/, label: 'runtime/node.exe' },
     ]

--- a/scripts/windowsStartBat.mjs
+++ b/scripts/windowsStartBat.mjs
@@ -1,0 +1,32 @@
+/** Windows 双击入口。%~dp0 末尾带 \\，不能写 /D "%~dp0"，否则引号被吃掉、窗口一闪就没。 */
+export function windowsStartBat() {
+  return [
+    '@echo off',
+    'chcp 65001 >nul',
+    'cd /d "%~dp0."',
+    'if not exist "data" mkdir data',
+    'echo [%date% %time%] start.bat cwd=%CD%>> data\\desktop-launch.log',
+    'if exist "desktop\\electron.exe" (',
+    '  echo [%date% %time%] launching electron>> data\\desktop-launch.log',
+    '  start "oh-my-co-work" /D "%~dp0." "%~dp0desktop\\electron.exe" "."',
+    '  exit /b 0',
+    ')',
+    'if exist "runtime\\node.exe" (',
+    '  echo [acw] 正在启动 oh-my-co-work（运行包，无需 npm install）…',
+    '  "runtime\\node.exe" start.mjs',
+    '  if errorlevel 1 pause',
+    '  exit /b %errorlevel%',
+    ')',
+    'where node >nul 2>nul',
+    'if errorlevel 1 (',
+    '  echo [acw] 未检测到 Node.js，请先安装 Node.js 18+ ：https://nodejs.org',
+    '  pause',
+    '  exit /b 1',
+    ')',
+    'echo [acw] 正在启动 oh-my-co-work（运行包，无需 npm install）…',
+    'echo [acw] 提示：关闭本窗口即可结束服务（关浏览器不会停）',
+    'node start.mjs',
+    'if errorlevel 1 pause',
+    '',
+  ].join('\r\n')
+}

--- a/start.bat
+++ b/start.bat
@@ -3,7 +3,7 @@ rem Keep this file ASCII-only and CRLF: cmd.exe seeks the next line by byte
 rem offset, so multibyte text plus "chcp 65001" truncates later lines.
 rem User-facing Chinese messages live in start.mjs instead.
 chcp 65001 >nul
-cd /d "%~dp0"
+cd /d "%~dp0."
 where node >nul 2>nul
 if errorlevel 1 (
   echo [acw] Node.js not found. Please install Node.js 18+ from https://nodejs.org


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

双击桌面包里的 `start.bat` 黑窗一闪、什么都没有。

`%~dp0` 末尾带 `\`，`start ... /D "%~dp0"` 会把闭合引号转义掉，Electron 根本没起来；批处理又立刻 `exit /b 0`。即便 exe 起来了，主进程也会先卡 60 秒健康检查才建窗口。

## 修复

- `start "oh-my-co-work" /D "%~dp0." "%~dp0desktop\electron.exe" "."`
- 先出窗口：「正在启动本机服务，请稍候…」，服务就绪后再进工作台
- 启动失败写 `data/desktop-launch.log` / `data/desktop-server.log`，并弹错误框

## 使用

请重新下载合并后 CI 打出的 **`oh-my-co-work-v4-win32-x64-desktop.zip`**。旧 zip 里的 `start.bat` 仍然是坏的。

大包仍不进 git（超过 GitHub 100MB）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5045363-04f3-481d-b678-7fc395609941?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5045363-04f3-481d-b678-7fc395609941&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

