### PR TITLE
fix: Windows 桌面启动 stdio WriteStream fd 为空

### DIFF
--- a/CODE_CHANGE.md
+++ b/CODE_CHANGE.md
@@ -22,6 +22,8 @@ YYYY-MM-DD | A/M/D/R | 文件路径 | 一句话说明（改了什么、为什么
 
 ## 变更记录
 
+2026-09-11 | M | electron/lib/server.mjs electron/main.js electron/test/urls-server.test.mjs | 后台服务日志改 openSync fd，禁止未打开 WriteStream 当 stdio（Windows 启动失败弹窗）
+
 2026-09-11 | M | eslint.config.js | electron/*.cjs 使用 Node 全局，避免 bootstrap.cjs 把 CI lint 打红
 2026-09-11 | M | scripts/windowsStartBat.mjs electron/main.js scripts/pack-release.mjs scripts/verify-pack.mjs package.json | 不再 cmd start；保留 default_app.asar；单例锁跟解压目录走
 2026-09-11 | M | electron/test/start-bat.test.mjs README.md | 断言不用 start；说明看 electron.log

--- a/electron/lib/server.mjs
+++ b/electron/lib/server.mjs
@@ -52,17 +52,37 @@ export async function isServerUp(port) {
   }
 }
 
-export function spawnAppServer({ appRoot, port, nodeBin, entry, logStream }) {
+export function openAppendFd(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  return fs.openSync(filePath, 'a')
+}
+
+/** spawn stdio 必须是已打开的 fd。WriteStream 在 'open' 之前 fd 为 null，Windows 上会直接抛 stdio invalid。 */
+export function stdioForChildLog(logFd) {
+  if (logFd == null) return 'ignore'
+  if (typeof logFd === 'object') {
+    const fd = logFd.fd
+    if (typeof fd !== 'number' || fd < 0) {
+      throw new Error('日志文件尚未打开，不能作为子进程 stdio')
+    }
+    return ['ignore', fd, fd]
+  }
+  if (typeof logFd !== 'number' || logFd < 0) {
+    throw new Error('logFd 必须是已打开的文件描述符')
+  }
+  return ['ignore', logFd, logFd]
+}
+
+export function spawnAppServer({ appRoot, port, nodeBin, entry, logFd }) {
   const env = {
     ...process.env,
     ACW_PORT: String(port),
     ACW_AUTO_EXIT: '0',
   }
-  const stdio = logStream ? ['ignore', logStream, logStream] : 'ignore'
   return spawn(nodeBin, [entry], {
     cwd: appRoot,
     env,
-    stdio,
+    stdio: stdioForChildLog(logFd),
     windowsHide: true,
   })
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -19,6 +19,7 @@ import {
   resolveNodeBin,
   resolveServerEntry,
   spawnAppServer,
+  openAppendFd,
   stopChild,
   waitHealth,
 } from './lib/server.mjs'
@@ -174,14 +175,19 @@ async function ensureServer() {
   const entry = resolveServerEntry(appRoot)
   fs.mkdirSync(path.join(appRoot, 'data'), { recursive: true })
   const logPath = path.join(appRoot, 'data', 'desktop-server.log')
-  const logStream = fs.createWriteStream(logPath, { flags: 'a' })
+  const logFd = openAppendFd(logPath)
   serverChild = spawnAppServer({
     appRoot,
     port,
     nodeBin,
     entry,
-    logStream,
+    logFd,
   })
+  try {
+    fs.closeSync(logFd)
+  } catch {
+    /* 子进程已复制 fd */
+  }
   serverChild.on('error', (err) => {
     if (!isQuitting) {
       dialog.showErrorBox('oh-my-co-work', `无法启动后台服务：${err?.message || err}`)

--- a/electron/test/start-bat.test.mjs
+++ b/electron/test/start-bat.test.mjs
@@ -35,4 +35,6 @@ test('desktop-launch 把解压目录作为 Electron 的应用路径', () => {
   assert.equal(calls[0].opts.cwd, dir)
   assert.equal(calls[0].opts.detached, true)
   assert.equal(calls[0].opts.windowsHide, false)
+  assert.equal(typeof calls[0].opts.stdio[1], 'number')
+  assert.equal(calls[0].opts.stdio[2], calls[0].opts.stdio[1])
 })

--- a/electron/test/urls-server.test.mjs
+++ b/electron/test/urls-server.test.mjs
@@ -3,8 +3,18 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import net from 'node:net'
+import { spawn } from 'node:child_process'
 import { desktopUpdateResult, normalizeAppOrigin, workbenchUrl } from '../lib/urls.mjs'
-import { resolveNodeBin, resolveServerEntry } from '../lib/server.mjs'
+import {
+  resolveNodeBin,
+  resolveServerEntry,
+  spawnAppServer,
+  stdioForChildLog,
+  openAppendFd,
+  waitHealth,
+  stopChild,
+} from '../lib/server.mjs'
 
 test('workbenchUrl 使用 history 路径而不是 hash 或 query', () => {
   assert.equal(workbenchUrl('http://127.0.0.1:3780', 's1'), 'http://127.0.0.1:3780/workbench/s1')
@@ -49,3 +59,61 @@ test('resolveServerEntry 优先打包入口', () => {
   const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'acw-empty-'))
   assert.throws(() => resolveServerEntry(empty), /找不到服务入口/)
 })
+
+test('未打开的 WriteStream 不能当 spawn stdio（Windows 弹窗：stdio invalid fd null）', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'acw-(a)-stdio-'))
+  const logPath = path.join(dir, 'desktop-server.log')
+  const stream = fs.createWriteStream(logPath, { flags: 'a' })
+  assert.equal(stream.fd, null)
+  assert.throws(() => stdioForChildLog(stream), /尚未打开/)
+  assert.throws(() => {
+    spawn(process.execPath, ['-e', ''], { stdio: ['ignore', stream, stream] })
+  }, /stdio|invalid/i)
+  stream.destroy()
+})
+
+test('openSync fd 可以 spawn 子进程，带括号的路径也能写日志并健康检查', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'acw-(a)-srv-'))
+  const entry = path.join(dir, 'health.cjs')
+  fs.writeFileSync(
+    entry,
+    [
+      "const http = require('http')",
+      'const port = Number(process.env.ACW_PORT)',
+      "http.createServer((req, res) => {",
+      "  if (req.url === '/api/health') { res.writeHead(200); res.end('ok'); return }",
+      '  res.writeHead(404); res.end()',
+      "}).listen(port, '127.0.0.1')",
+      "process.stdout.write('server-up\\n')",
+      '',
+    ].join('\n'),
+  )
+  const port = await new Promise((resolve, reject) => {
+    const s = net.createServer()
+    s.listen(0, '127.0.0.1', () => {
+      const addr = s.address()
+      const p = typeof addr === 'object' && addr ? addr.port : 0
+      s.close((err) => (err ? reject(err) : resolve(p)))
+    })
+    s.on('error', reject)
+  })
+  const logPath = path.join(dir, 'data', 'desktop-server.log')
+  const logFd = openAppendFd(logPath)
+  const child = spawnAppServer({
+    appRoot: dir,
+    port,
+    nodeBin: process.execPath,
+    entry,
+    logFd,
+  })
+  fs.closeSync(logFd)
+  try {
+    await waitHealth(port, 8000)
+    const log = fs.readFileSync(logPath, 'utf8')
+    assert.match(log, /server-up/)
+  } finally {
+    stopChild(child)
+    await new Promise((r) => setTimeout(r, 200))
+  }
+})
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
窗口已经能出来了。随后弹窗：

`The argument 'stdio' is invalid. Received WriteStream { fd: null }`

原因：`fs.createWriteStream` 还没打开文件就把 stream 交给 `spawn` 的 stdio。Node 在 Windows 上会直接扔这个错。

修复：用 `openSync` 拿到真实 fd 再 spawn。自测包括：

- 复现「未打开 WriteStream + spawn」必失败
- 在带括号的临时目录里真实拉起子进程、写日志、打 `/api/health`
- 对本仓库 `server/src` 做了一次同样的 spawn 冒烟（`SMOKE_OK`）

请重新下载合并后的 `*-win32-x64-desktop.zip`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5045363-04f3-481d-b678-7fc395609941?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5045363-04f3-481d-b678-7fc395609941&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

